### PR TITLE
V0.4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           mkdir -p release_artifacts/${{ matrix.target }}
           cd target/${{ matrix.target }}/release
-changed          mkdir -p rtimelogger-${{ matrix.target }}
+          mkdir -p rtimelogger-${{ matrix.target }}
           
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             cp rtimelogger.exe rtimelogger-${{ matrix.target }}/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,29 +65,29 @@ jobs:
         run: |
           mkdir -p release_artifacts/${{ matrix.target }}
           cd target/${{ matrix.target }}/release
-          mkdir -p rtimelog-${{ matrix.target }}
+changed          mkdir -p rtimelogger-${{ matrix.target }}
           
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            cp rtimelog.exe rtimelog-${{ matrix.target }}/
+            cp rtimelogger.exe rtimelogger-${{ matrix.target }}/
           else
-            cp rtimelog rtimelog-${{ matrix.target }}/
+            cp rtimelogger rtimelogger-${{ matrix.target }}/
           fi
           
-          cp $GITHUB_WORKSPACE/{README.md,LICENSE,CHANGELOG.md} rtimelog-${{ matrix.target }}/
+          cp $GITHUB_WORKSPACE/{README.md,LICENSE,CHANGELOG.md} rtimelogger-${{ matrix.target }}/
           
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            powershell -Command "Compress-Archive -Path rtimelog-${{ matrix.target }}\\* -DestinationPath rtimelog-${VERSION}-${{ matrix.target }}.zip"
-            cp rtimelog-${VERSION}-${{ matrix.target }}.zip $GITHUB_WORKSPACE/release_artifacts/${{ matrix.target }}/
+            powershell -Command "Compress-Archive -Path rtimelogger-${{ matrix.target }}\\* -DestinationPath rtimelogger-${VERSION}-${{ matrix.target }}.zip"
+            cp rtimelogger-${VERSION}-${{ matrix.target }}.zip $GITHUB_WORKSPACE/release_artifacts/${{ matrix.target }}/
           else
-            tar -czvf rtimelog-${VERSION}-${{ matrix.target }}.tar.gz rtimelog-${{ matrix.target }}
-            cp rtimelog-${VERSION}-${{ matrix.target }}.tar.gz $GITHUB_WORKSPACE/release_artifacts/${{ matrix.target }}/
+            tar -czvf rtimelogger-${VERSION}-${{ matrix.target }}.tar.gz rtimelogger-${{ matrix.target }}
+            cp rtimelogger-${VERSION}-${{ matrix.target }}.tar.gz $GITHUB_WORKSPACE/release_artifacts/${{ matrix.target }}/
           fi
       
       - name: Generate SHA256 checksum
         shell: bash
         run: |
           cd release_artifacts/${{ matrix.target }}
-          file="rtimelog-${VERSION}-${{ matrix.target }}.${{ matrix.ext }}"
+          file="rtimelogger-${VERSION}-${{ matrix.target }}.${{ matrix.ext }}"
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             pwsh -Command '
               $file = "'"$file"'"
@@ -102,7 +102,7 @@ jobs:
         shell: bash
         run: |
           cd release_artifacts/${{ matrix.target }}
-          file="rtimelog-${VERSION}-${{ matrix.target }}.${{ matrix.ext }}"
+          file="rtimelogger-${VERSION}-${{ matrix.target }}.${{ matrix.ext }}"
           echo "$GPG_PRIVATE_KEY" | base64 --decode | gpg --batch --import
           
           echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 \
@@ -172,9 +172,9 @@ jobs:
           name: "v${{ steps.extract_version.outputs.version }}"
           body_path: CHANGELOG.md
           files: |
-            release_artifacts/rtimelog-*.tar.gz
-            release_artifacts/rtimelog-*.zip
-            release_artifacts/rtimelog-*.sig
-            release_artifacts/rtimelog-*.sha256
+            release_artifacts/rtimelogger-*.tar.gz
+            release_artifacts/rtimelogger-*.zip
+            release_artifacts/rtimelogger-*.sig
+            release_artifacts/rtimelogger-*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.4.5] - 2025-10-06
+
+### Changed
+- Project renamed from **`rtimelog`** to **`rtimelogger`**.
+- No functional changes: this release only updates the crate name, repository links, badges, and documentation references.
+
+---
+
 # [0.4.2] - 2025-10-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,8 +467,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "rtimelog"
-version = "0.4.2"
+name = "rtimelogger"
+version = "0.4.5"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "rtimelog"
-version = "0.4.2"
+name = "rtimelogger"
+version = "0.4.5"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"
-homepage = "https://github.com/umpire274/rTimelog"
-repository = "https://github.com/umpire274/rTimelog"
+homepage = "https://github.com/umpire274/rTimelogger"
+repository = "https://github.com/umpire274/rTimelogger"
 license = "MIT"
 readme = "README.md"
 keywords = ["timelog", "work-tracking", "cli", "productivity", "sqlite"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # rTimelog
 
-[![Build Status](https://github.com/umpire274/rTimelog/actions/workflows/ci.yml/badge.svg)](https://github.com/umpire274/rTimelog/actions/workflows/ci.yml)
-[![Latest Release](https://img.shields.io/github/v/release/umpire274/rTimelog)](https://github.com/umpire274/rTimelog/releases)
-[![codecov](https://codecov.io/gh/umpire274/rTimelog/graph/badge.svg?token=5WPQF58D5Z)](https://codecov.io/gh/umpire274/rTimelog)
+[![Build Status](https://github.com/umpire274/rTimelogger/actions/workflows/ci.yml/badge.svg)](https://github.com/umpire274/rTimelogger/actions/workflows/ci.yml)
+[![Latest Release](https://img.shields.io/github/v/release/umpire274/rTimelogger)](https://github.com/umpire274/rTimelogger/releases)
+[![codecov](https://codecov.io/gh/umpire274/rTimelogger/graph/badge.svg?token=5WPQF58D5Z)](https://codecov.io/gh/umpire274/rTimelogger
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT))
 
 `rTimelog` is a simple, cross-platform **command-line tool** written in Rust to track daily working sessions, including
 working position, start and end times, and lunch breaks.  
@@ -10,23 +11,11 @@ The tool calculates the expected exit time and the surplus of worked minutes.
 
 ---
 
-## What's new in v0.4.2
+## What's new in 0.4.5
 
-**Delete-by-date/pair, mixed position and quality fixes**
-
-This release brings safer deletion primitives, a new mixed position flag and a number of internal cleanups:
-
-- New deletion mode:
-    - `del <date>` deletes all events and legacy `work_sessions` rows for the given date (interactive confirmation).
-    - `del --pair <pair> <date>` deletes only events belonging to the given pair for that date (interactive
-      confirmation). If no events remain for the date the legacy `work_sessions` row(s) are removed as well.
-- Database: introduced position value `M` (Mixed) to mark days with multiple positions and added a migration to extend
-  the CHECK constraints.
-- Code: extracted `create_missing_event` helper into `src/events.rs` (unit-tested) and removed duplicated logic from
-  `commands.rs`.
-- Tests: integration tests added/updated to cover deletion-by-date and deletion-by-pair behavior.
-- Lint: fixed a Clippy warning to allow `cargo clippy -D warnings` to pass.
-- `del` now records concise audit entries into the internal `log` table (visible with `rtimelog log --print`).
+- The project has been **renamed** from `rtimelog` to `rtimelogger`.
+- No new features or bug fixes have been introduced in this release.
+- All references in the crate name, repository links, documentation, and badges have been updated accordingly.
 
 ---
 
@@ -70,25 +59,25 @@ This release brings safer deletion primitives, a new mixed position flag and a n
 
 ## 📦 Installation
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/rtimelog.svg)](https://repology.org/project/rtimelog/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/rtimelogger.svg)](https://repology.org/project/rtimelogger/versions)
 
 ### 🐧 AUR (Arch Linux)
 
-[![AUR](https://img.shields.io/aur/version/rtimelog)](https://aur.archlinux.org/packages/rtimelog)
+[![AUR](https://img.shields.io/aur/version/rtimelogger)](https://aur.archlinux.org/packages/rtimelogger)
 
 ```bash
-yay -S rtimelog
+yay -S rtimelogger
 # or
-paru -S rtimelog
+paru -S rtimelogger
 ```
 
 ### 🍺 Homebrew (macOS/Linux)
 
-[![Homebrew Tap](https://img.shields.io/badge/homebrew-tap-brightgreen)](https://github.com/umpire274/homebrew-rtimelog)
+[![Homebrew Tap](https://img.shields.io/badge/homebrew-tap-brightgreen)](https://github.com/umpire274/homebrew-rtimelogger)
 
 ```bash
-brew tap umpire274/rtimelog
-brew install rtimelog
+brew tap umpire274/rtimelogger
+brew install rtimelogger
 ```
 
 ---

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,10 @@
 use crate::Cli;
 use crate::Commands;
 use chrono::NaiveTime;
-use rtimelog::config::Config;
-use rtimelog::utils::{describe_position, mins2hhmm, print_separator};
-use rtimelog::{db, logic, utils};
+use rtimelogger::config::Config;
+use rtimelogger::events::create_missing_event;
+use rtimelogger::utils::{describe_position, mins2hhmm, print_separator};
+use rtimelogger::{db, logic, utils};
 use rusqlite::Connection;
 use std::io::{Write, stdin};
 use std::process::Command;
@@ -317,7 +318,7 @@ pub fn handle_add(cmd: &Commands, conn: &mut Connection, config: &Config) -> rus
             if let Some(sv) = start.as_ref()
                 && in_event.is_none()
             {
-                in_event = rtimelog::events::create_missing_event(
+                in_event = create_missing_event(
                     conn,
                     date,
                     sv.as_str(),
@@ -332,7 +333,7 @@ pub fn handle_add(cmd: &Commands, conn: &mut Connection, config: &Config) -> rus
             if let Some(ev_t) = end.as_ref()
                 && out_event.is_none()
             {
-                out_event = rtimelog::events::create_missing_event(
+                out_event = create_missing_event(
                     conn,
                     date,
                     ev_t.as_str(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
-use rtimelog::config::Config;
-use rtimelog::db;
+use rtimelogger::config::Config;
+use rtimelogger::db;
 use rusqlite::Connection;
 
 mod commands;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 fn setup_test_db(name: &str) -> String {
     // Cross-platform: /tmp su Linux/macOS, %TEMP% su Windows
     let mut path: PathBuf = env::temp_dir();
-    path.push(format!("{}_rtimelog.sqlite", name));
+    path.push(format!("{}_rtimelogger.sqlite", name));
 
     let db_path = path.to_string_lossy().to_string();
 
@@ -22,13 +22,13 @@ fn setup_test_db(name: &str) -> String {
 fn test_list_sessions_all() {
     let db_path = setup_test_db("all");
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -43,7 +43,7 @@ fn test_list_sessions_all() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -58,7 +58,7 @@ fn test_list_sessions_all() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -73,7 +73,7 @@ fn test_list_sessions_all() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list"])
         .assert()
@@ -87,13 +87,13 @@ fn test_list_sessions_all() {
 fn test_list_sessions_filter_year() {
     let db_path = setup_test_db("year");
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -108,7 +108,7 @@ fn test_list_sessions_filter_year() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -123,7 +123,7 @@ fn test_list_sessions_filter_year() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -138,7 +138,7 @@ fn test_list_sessions_filter_year() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list", "--period", "2025"])
         .assert()
@@ -157,13 +157,13 @@ fn test_list_sessions_filter_year() {
 fn test_list_sessions_filter_year_month() {
     let db_path = setup_test_db("year_month");
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -178,7 +178,7 @@ fn test_list_sessions_filter_year_month() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -193,7 +193,7 @@ fn test_list_sessions_filter_year_month() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -208,7 +208,7 @@ fn test_list_sessions_filter_year_month() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -223,7 +223,7 @@ fn test_list_sessions_filter_year_month() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list", "--period", "2025-09"])
         .assert()
@@ -248,14 +248,14 @@ fn test_list_sessions_filter_position() {
     let db_path = setup_test_db("filter_position");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add Office (O)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -272,7 +272,7 @@ fn test_list_sessions_filter_position() {
         .success();
 
     // Add Remote (R)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -289,14 +289,14 @@ fn test_list_sessions_filter_position() {
         .success();
 
     // Add Holiday (H)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "add", "2025-09-12", "H"])
         .assert()
         .success();
 
     // Filter O
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--pos", "O"])
         .assert()
@@ -307,7 +307,7 @@ fn test_list_sessions_filter_position() {
         .stdout(contains("2025-09-12").not());
 
     // Filter R
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--pos", "R"])
         .assert()
@@ -318,7 +318,7 @@ fn test_list_sessions_filter_position() {
         .stdout(contains("2025-09-12").not());
 
     // Filter H
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--pos", "H"])
         .assert()
@@ -333,13 +333,13 @@ fn test_list_sessions_filter_position() {
 fn test_list_sessions_invalid_period() {
     let db_path = setup_test_db("invalid_period");
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -354,7 +354,7 @@ fn test_list_sessions_invalid_period() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list", "--period", "2025-9"])
         .assert()
@@ -367,14 +367,14 @@ fn test_add_and_list_with_company_position() {
     let db_path = setup_test_db("with_company_position");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add a session in company mode (A), crossing lunch window but without specifying lunch
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -390,7 +390,7 @@ fn test_add_and_list_with_company_position() {
         .success();
 
     // List should show Pos A and Lunch 30 min (auto-applied)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list"])
         .assert()
@@ -406,14 +406,14 @@ fn test_add_and_list_with_remote_position_lunch_zero() {
     let db_path = setup_test_db("with_remote_position_lunch_zero");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add a session in remote mode (R), crossing lunch window, no lunch specified
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -429,7 +429,7 @@ fn test_add_and_list_with_remote_position_lunch_zero() {
         .success();
 
     // List should show Pos R and Lunch 0 min (allowed)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list"])
         .assert()
@@ -443,21 +443,21 @@ fn test_add_and_list_incomplete_session() {
     let db_path = setup_test_db("incomplete_session");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add only start time (no end)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "add", "2025-09-16", "O", "09:00"])
         .assert()
         .success();
 
     // List should show Pos A and Start 09:00 but End "-"
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list"])
         .assert()
@@ -472,14 +472,14 @@ fn test_add_and_list_holiday_position() {
     let db_path = setup_test_db("holiday_position");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Adding a day with Holiday position
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -495,7 +495,7 @@ fn test_add_and_list_holiday_position() {
         .stdout(contains("Position Holiday"));
 
     // List should show 'Holiday' as position and no more data's
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list"])
         .assert()
@@ -517,7 +517,7 @@ fn test_list_sessions_positions_with_colors() {
         let db_path = setup_test_db(&format!("pos_{}", pos));
 
         // Init DB
-        Command::cargo_bin("rtimelog")
+        Command::cargo_bin("rtimelogger")
             .unwrap()
             .args(["--db", &db_path, "--test", "init"])
             .assert()
@@ -529,14 +529,14 @@ fn test_list_sessions_positions_with_colors() {
             args.extend(&["09:00", "30", "17:00"]);
         }
 
-        Command::cargo_bin("rtimelog")
+        Command::cargo_bin("rtimelogger")
             .unwrap()
             .args(&args)
             .assert()
             .success();
 
         // List filtrato per posizione → deve contenere label e colore
-        Command::cargo_bin("rtimelog")
+        Command::cargo_bin("rtimelogger")
             .unwrap()
             .args(["--db", &db_path, "--test", "list", "--pos", pos])
             .assert()
@@ -551,14 +551,14 @@ fn test_add_and_delete_session() {
     let db_path = setup_test_db("delete_session");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add a session
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -575,7 +575,7 @@ fn test_add_and_delete_session() {
         .success();
 
     // Verify session is listed
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list"])
         .assert()
@@ -583,7 +583,7 @@ fn test_add_and_delete_session() {
         .stdout(contains("2025-09-20"));
 
     // Delete by date (new behavior) -- answer 'y' to confirmation prompt
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "del", "2025-09-20"])
         .write_stdin("y\n")
@@ -592,7 +592,7 @@ fn test_add_and_delete_session() {
         .stdout(contains("Deleted").or(contains("deleted")));
 
     // Verify session no longer appears in list
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list"])
         .assert()
@@ -605,14 +605,14 @@ fn test_delete_nonexistent_session() {
     let db_path = setup_test_db("delete_nonexistent");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Try to delete a date that does not exist: confirm with 'y' and expect 0 rows deleted
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "del", "2099-01-01"])
         .write_stdin("y\n")
@@ -628,14 +628,14 @@ fn test_separator_after_month_end() {
     let db_path = setup_test_db("separator_month_end");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add last day of September and first day of October
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -650,7 +650,7 @@ fn test_separator_after_month_end() {
         .assert()
         .success();
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -668,7 +668,7 @@ fn test_separator_after_month_end() {
     // List and assert separator (25 '-' characters) is present after the 2025-09-30 line
     let sep25 = "-".repeat(25);
 
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "list"])
         .assert()
@@ -682,14 +682,14 @@ fn test_list_events_filter_position_case_insensitive() {
     let db_path = setup_test_db("events_pos_case");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add Remote (R) session which creates two events (in/out)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -706,7 +706,7 @@ fn test_list_events_filter_position_case_insensitive() {
         .success();
 
     // Add Office (O) session
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -723,7 +723,7 @@ fn test_list_events_filter_position_case_insensitive() {
         .success();
 
     // List events filtering with lowercase 'r' to verify case-insensitive normalization
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events", "--pos", "r"])
         .assert()
@@ -737,14 +737,14 @@ fn test_events_pair_column_and_grouping() {
     let db_path = setup_test_db("events_pair_col");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Prima sessione (in/out)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -761,7 +761,7 @@ fn test_events_pair_column_and_grouping() {
         .success();
 
     // Seconda sessione (in/out)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -778,7 +778,7 @@ fn test_events_pair_column_and_grouping() {
         .success();
 
     // Lista eventi e verifica intestazione Pair e presenza dei pair id 1 e 2
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events", "--pos", "R"])
         .assert()
@@ -793,14 +793,14 @@ fn test_delete_existing_pair() {
     let db_path = setup_test_db("delete_existing_pair");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Pair 1 (09:00-12:00)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -817,7 +817,7 @@ fn test_delete_existing_pair() {
         .success();
 
     // Pair 2 (13:00-17:00)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -834,7 +834,7 @@ fn test_delete_existing_pair() {
         .success();
 
     // Delete pair 1 (confirm 'y')
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -851,7 +851,7 @@ fn test_delete_existing_pair() {
         .stdout(contains("Deleted").or(contains("deleted")));
 
     // List events and ensure pair1 times are gone, pair2 remains
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events"])
         .assert()
@@ -867,14 +867,14 @@ fn test_delete_nonexistent_pair() {
     let db_path = setup_test_db("delete_nonexistent_pair");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add a single pair (so pair id 1 exists)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -891,7 +891,7 @@ fn test_delete_nonexistent_pair() {
         .success();
 
     // Try to delete a non-existent pair 5 on that date
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -912,14 +912,14 @@ fn test_delete_pair_updates_work_session() {
     let db_path = setup_test_db("delete_pair_updates_ws");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Pair 1: R 08:35 - 17:00 with 30 lunch
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -936,7 +936,7 @@ fn test_delete_pair_updates_work_session() {
         .success();
 
     // Pair 2: C 17:45 - 20:00
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -953,7 +953,7 @@ fn test_delete_pair_updates_work_session() {
         .success();
 
     // Delete pair 2
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -988,14 +988,14 @@ fn test_delete_pair_with_mixed_positions_leaves_position_unchanged() {
     let db_path = setup_test_db("delete_pair_mixed_positions");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Pair 1: R 08:00 - 09:00
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -1012,7 +1012,7 @@ fn test_delete_pair_with_mixed_positions_leaves_position_unchanged() {
         .success();
 
     // Pair 2: O 10:00 - 11:00
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -1029,7 +1029,7 @@ fn test_delete_pair_with_mixed_positions_leaves_position_unchanged() {
         .success();
 
     // Pair 3: C 12:00 - 13:00
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -1063,7 +1063,7 @@ fn test_delete_pair_with_mixed_positions_leaves_position_unchanged() {
     assert_eq!(end_before, "13:00");
 
     // Delete pair 2 (the middle one with position O) -> remaining positions are R and C (mixed)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",

--- a/tests/logic_tests.rs
+++ b/tests/logic_tests.rs
@@ -1,7 +1,7 @@
 use chrono::{Duration, NaiveTime};
-use rtimelog::logic::month_name;
-use rtimelog::utils::mins2hhmm;
-use rtimelog::{logic, utils};
+use rtimelogger::logic::month_name;
+use rtimelogger::utils::mins2hhmm;
+use rtimelogger::{logic, utils};
 
 #[test]
 fn test_expected_exit_with_min_lunch() {

--- a/tests/missing_event_tests.rs
+++ b/tests/missing_event_tests.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 /// Create a unique test DB path inside the system temp dir
 fn setup_test_db(name: &str) -> String {
     let mut path: PathBuf = env::temp_dir();
-    path.push(format!("{}_rtimelog.sqlite", name));
+    path.push(format!("{}_rtimelogger.sqlite", name));
     let db_path = path.to_string_lossy().to_string();
     let _ = std::fs::remove_file(&db_path);
     db_path
@@ -17,21 +17,21 @@ fn test_create_missing_in_when_only_out_exists() {
     let db_path = setup_test_db("missing_event_in");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Create only an OUT event for the date (no start)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "add", "2025-10-01", "--out", "17:00"])
         .assert()
         .success();
 
     // Verify currently there is a single out event
-    let out_only = Command::cargo_bin("rtimelog")
+    let out_only = Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events", "--json"])
         .output()
@@ -43,7 +43,7 @@ fn test_create_missing_in_when_only_out_exists() {
     assert_eq!(arr[0]["kind"], "out");
 
     // Now use explicit edit on pair 1 to add the missing IN event
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -60,7 +60,7 @@ fn test_create_missing_in_when_only_out_exists() {
         .success();
 
     // Re-list events and expect both in and out
-    let both = Command::cargo_bin("rtimelog")
+    let both = Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events", "--json"])
         .output()

--- a/tests/update_pair_tests.rs
+++ b/tests/update_pair_tests.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 /// Create a unique test DB path inside the system temp dir
 fn setup_test_db(name: &str) -> String {
     let mut path: PathBuf = env::temp_dir();
-    path.push(format!("{}_rtimelog.sqlite", name));
+    path.push(format!("{}_rtimelogger.sqlite", name));
     let db_path = path.to_string_lossy().to_string();
     let _ = std::fs::remove_file(&db_path);
     db_path
@@ -17,14 +17,14 @@ fn test_update_does_not_create_new_pair() {
     let db_path = setup_test_db("update_pair");
 
     // Init DB
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
     // Add initial full session -> produces exactly 2 events (in/out) with pair=1
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -40,7 +40,7 @@ fn test_update_does_not_create_new_pair() {
         .success();
 
     // Capture events JSON after initial insert
-    let initial_output = Command::cargo_bin("rtimelog")
+    let initial_output = Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events", "--json"])
         .output()
@@ -68,7 +68,7 @@ fn test_update_does_not_create_new_pair() {
     let out_id = init_out["id"].as_i64().unwrap();
 
     // Update ONLY start time via explicit edit (pair 1)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -85,7 +85,7 @@ fn test_update_does_not_create_new_pair() {
         .success();
 
     // Update ONLY end time via explicit edit (pair 1)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -102,7 +102,7 @@ fn test_update_does_not_create_new_pair() {
         .success();
 
     // Update ONLY lunch via explicit edit (pair 1)
-    Command::cargo_bin("rtimelog")
+    Command::cargo_bin("rtimelogger")
         .unwrap()
         .args([
             "--db",
@@ -119,7 +119,7 @@ fn test_update_does_not_create_new_pair() {
         .success();
 
     // Re-capture events JSON after updates
-    let final_output = Command::cargo_bin("rtimelog")
+    let final_output = Command::cargo_bin("rtimelogger")
         .unwrap()
         .args(["--db", &db_path, "--test", "list", "--events", "--json"])
         .output()

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use chrono::{NaiveDate, NaiveDateTime};
-    use rtimelog::utils::{
+    use rtimelogger::utils::{
         date2iso, datetime2iso, describe_position, iso2date, iso2datetime, make_separator,
     };
 


### PR DESCRIPTION
## [0.4.5] - 2025-10-06

### Changed
- Project renamed from **`rtimelog`** to **`rtimelogger`**.
- No functional changes: this release only updates the crate name, repository links, badges, and documentation references.
