### PR TITLE
Improve list output, add compact view, and refine weekday handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.1] - 2026-01-07
+
+### Fixed
+
+- `add`: allow `--pos H` (Holiday) without requiring `--in`/`--out`.
+
+---
+
 ## [v0.8.0] - 2025-12-18
 
 ### 🚀 Stable release — Timeline & Work Gap engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,42 @@
 
 ## [0.8.1] - 2026-01-07
 
-### Added
+### ✨ New
 
-- `add`: support for **Holiday day marker** using `--pos H`, without requiring `--in` or `--out`.
+- Added list --compact output mode for a concise, single-line daily overview.
+- Introduced unified date column format YYYY-MM-DD (WD) with configurable weekday length.
+- Improved visual hierarchy for list --details with highlighted DETAILS section header.
+- Added dynamic table width handling based on weekday display mode (None, Short, Medium, Long).
 
-### Fixed
+### 🔧 Improvements
 
-- `add`: improved validation logic for argument combinations involving `--pos H`.
-- `list`: correct handling of Holiday days in daily summaries (no times, no surplus).
-- `list`: prevent Holiday entries from affecting pairing and surplus calculations.
+- Refactored list command rendering logic for better layout consistency and maintainability.
+- Harmonized table headers and footers across standard and compact list views.
+- Improved footer alignment using dynamic table width calculation.
+- Clarified labels:
+    - Expected → Target end
+    - Surplus → ΔWORK
+- Enhanced compact delta formatting (e.g. +02h04m).
+- Automatic re-print of table headers when switching month during period listing.
+- Improved holiday visualization:
+    - All time fields shown as --:--
+    - Greyed output
+    - Neutral contribution to totals.
 
-### Changed
+### 🐞 Fixes
 
-- `list`: redesigned daily summary output with a compact tabular layout.
-- `list`: clarified `Expected` value as **Target end** (planned exit time).
-- `list --details`: replaced verbose output with a structured table for IN/OUT pairs.
-- `list`: added section headers and harmonized footer styling.
-- CLI error handling: introduced `InvalidArgs` to distinguish argument validation errors from parsing errors.
+- Fixed incorrect handling of --pos h (Holiday) requiring --in/--out.
+- Fixed misleading error classification (InvalidTime → InvalidArgs) for invalid CLI combinations.
+- Fixed surplus calculation edge cases when work gaps are present.
+- Fixed weekday width/layout inconsistencies across different display modes.
+- Removed unused variables and eliminated compiler warnings in list.rs.
+
+### 🧹 Internal
+
+- Introduced WeekdayMode enum for explicit weekday rendering control.
+- Centralized table width logic via utils::table constants.
+- Simplified footer formatting and alignment logic.
+- Improved separation between presentation logic and data computation.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,23 @@
 
 ## [0.8.1] - 2026-01-07
 
+### Added
+
+- `add`: support for **Holiday day marker** using `--pos H`, without requiring `--in` or `--out`.
+
 ### Fixed
 
-- `add`: allow `--pos H` (Holiday) as a day marker without requiring `--in` or `--out`.
-- Improved CLI validation errors by distinguishing invalid arguments from time parsing errors.
+- `add`: improved validation logic for argument combinations involving `--pos H`.
+- `list`: correct handling of Holiday days in daily summaries (no times, no surplus).
+- `list`: prevent Holiday entries from affecting pairing and surplus calculations.
 
----
+### Changed
 
-## [v0.8.0] - 2025-12-18
-
-### 🚀 Stable release — Timeline & Work Gap engine
-
-This release marks the **first stable 0.8.x version** and concludes the alpha/beta cycle with a fully consolidated
-timeline engine, correct multi-pair handling, and a refined CLI experience.
+- `list`: redesigned daily summary output with a compact tabular layout.
+- `list`: clarified `Expected` value as **Target end** (planned exit time).
+- `list --details`: replaced verbose output with a structured table for IN/OUT pairs.
+- `list`: added section headers and harmonized footer styling.
+- CLI error handling: introduced `InvalidArgs` to distinguish argument validation errors from parsing errors.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@
 
 ---
 
+## [v0.8.0] - 2025-12-18
+
+### 🚀 Stable release — Timeline & Work Gap engine
+
+This release marks the **first stable 0.8.x version** and concludes the alpha/beta cycle with a fully consolidated
+timeline engine, correct multi-pair handling, and a refined CLI experience.
+
+---
+
 ### ✨ Highlights
 
 - **Stable multi-pair daily model**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- `add`: allow `--pos H` (Holiday) without requiring `--in`/`--out`.
+- `add`: allow `--pos H` (Holiday) as a day marker without requiring `--in` or `--out`.
+- Improved CLI validation errors by distinguishing invalid arguments from time parsing errors.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -502,26 +502,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -570,7 +564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -639,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
  "cc",
  "pkg-config",
@@ -671,9 +665,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.13.0"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
+checksum = "17f7337d278fec032975dc884152491580dd23750ee957047856735fe0e61ede"
 dependencies = [
  "crc",
  "sha2",
@@ -879,7 +873,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rtimelogger"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ansi_term",
  "assert_cmd",
@@ -901,14 +895,14 @@ dependencies = [
  "time",
  "unicode-width",
  "winresource",
- "zip",
+ "zip 7.0.0",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -916,15 +910,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
 name = "rust_xlsxwriter"
-version = "0.92.2"
+version = "0.92.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8b9faf2c68874f865272c92493e9bb811e5fdff197a56ecc4748885ec5a874"
+checksum = "0733a44f344e900c4221f33a16aa92a59e3e7c7ad37d39a1c753afecb1f2bd02"
 dependencies = [
- "zip",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -1056,6 +1051,19 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
+dependencies = [
+ "cc",
+ "hashbrown",
+ "js-sys",
+ "thiserror",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "strsim"
@@ -1508,6 +1516,20 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd8a47718a4ee5fe78e07667cd36f3de80e7c2bfe727c7074245ffc7303c037"
+dependencies = [
  "aes",
  "arbitrary",
  "bzip2",
@@ -1515,6 +1537,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
+ "generic-array",
  "getrandom 0.3.4",
  "hmac",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtimelogger"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"
@@ -30,18 +30,18 @@ LegalCopyright = "© 2025 Alessandro Maestri"
 Icon = "res/rtimelogger.ico"
 
 [dependencies]
-rusqlite = { version = "0.37.0", features = ["bundled"] }
-clap = { version = "4.5.53", features = ["derive"] }
+rusqlite = { version = "0.38.0", features = ["bundled"] }
+clap = { version = "4.5.54", features = ["derive"] }
 predicates = "3.1.3"
 assert_cmd = "2.1.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml = "0.9.33"
 serde_json = "1.0.145"
-zip = "6.0.0"
+zip = "7.0.0"
 flate2 = "1.1.5"
 tar = "0.4.44"
 csv = "1.4.0"
-rust_xlsxwriter = "0.92.2"
+rust_xlsxwriter = "0.92.3"
 unicode-width = "0.2.2"
 pdf-writer = "0.14.0"
 dirs = "6.0.0"

--- a/README.md
+++ b/README.md
@@ -201,29 +201,170 @@ rtimelogger add 2025-12-15 --edit --pair 2 --no-work-gap
 
 ---
 
-## 📋 List data — `rtimelogger list`
+## 📋 Listing sessions — `rtimelogger list`
+
+The `list` command displays saved work sessions, supporting multiple layouts and levels of detail.
+
+### **Basic usage**:
 
 ```bash
 rtimelogger list                     # current month
-rtimelogger list --today
-rtimelogger list --period 2025-12
-rtimelogger list --period 2025-12-15
-rtimelogger list --events
 ```
 
-### ℹ️ Note on `--details`
+Shows the sessions for the current month using the default tabular layout.
 
-`--details` is valid **only** with:
-
-* `--today`
-* `--period <single day>`
-
-Examples:
+### 📅 **Supported periods**
 
 ```bash
-rtimelogger list --today --details
-rtimelogger list --period 2025-12-15 --details
+rtimelogger list --period 2025-12
+rtimelogger list --period 2025
+rtimelogger list --period 2025-12-01
+rtimelogger list --period 2025-12-01:2025-12-31
+rtimelogger list --period all
 ```
+
+### 📆 **Weekday display**
+
+The weekday is shown inside the date column, using the format:
+
+```text
+YYYY-MM-DD (Mo)
+YYYY-MM-DD (Monday)
+```
+
+The format is controlled by the show_weekday configuration option:
+
+| Value    | Output example        |
+|----------|-----------------------|
+| `none`   | `2025-12-19`          |
+| `short`  | `2025-12-19 (Mo)`     |
+| `medium` | `2025-12-19 (Mon)`    |
+| `long`   | `2025-12-19 (Monday)` |
+
+### 📊 Standard output
+
+```bash
+rtimelogger list --period 2025-12
+```
+
+Example:
+
+```text
+DATE (WD)        | POSITION        |  IN   | LNCH  |  OUT  |  TGT  |  ΔWORK
+---------------------------------------------------------------------------
+2025-12-19 (Fr)  | Remote          | 08:55 | 00:30 | 18:27 | 17:01 | -02h04m
+```
+
+**Columns explained**:
+
+- **IN** – first check-in of the day
+- **LNCH** – total lunch break duration
+- **OUT** – last check-out
+- **TGT** – planned exit time (minimum required work time)
+- **ΔWORK** – worked surplus or deficit
+
+### 🧾 Pair details (--details)
+
+```bash
+rtimelogger list --period 2025-12-19 --details
+```
+
+Displays the **individual** IN/OUT pairs for the selected day. It is available **only** for single-day periods or
+`--today`.
+
+**Output example**:
+
+```text
+DETAILS
+PAIR |  IN   |  OUT  | WORKED | LUNCH | POSITION | WG
+------------------------------------------------------
+  1  | 08:55 | 09:37 | 00h42m |  0m   | Remote   |
+  2  | 13:07 | 18:27 | 04h50m | 30m   | Remote   |
+```
+
+**Columns explained**:
+
+- **PAIR** – pair index
+- **IN** / **OUT** – timestamps for the pair
+- **WORKED** – worked time for the pair
+- **LUNCH** – lunch break for the pair
+- **POSITION** – position for the pair
+- **WG** – working gap indicator (🔗 for working gap, ✂️ for non-working gap)
+
+### 📦 Compact view (--compact)
+
+```bash
+rtimelogger list --period 2025-12 --compact
+```
+
+Shows a condensed, single-line-per-day view, suitable for long periods.
+
+Example:
+
+```text
+DATE (WD)        | POSITION | IN / LNCH / OUT       | TGT   | ΔWORK
+--------------------------------------------------------------------
+2025-12-19 (Fr)  | Remote   | 08:55 / 00:30 / 18:27 | 17:01 | Δ -02h04m
+2025-12-22 (Mo)  | Holiday  | --:-- / --:-- / --:-- | --:-- | Δ -
+```
+
+**Characteristics**:
+
+- compact horizontal layout
+- weekday forced to short format
+- no pair details
+
+> ⚠️ `--compact` **cannot be combined** with `--details`
+
+### Events listing (--events)
+
+```bash
+rtimelogger list --period 2025-12-15 --events
+```
+
+Displays the raw IN / OUT events for the selected day.
+
+**Output example**:
+
+```text
+EVENTS:
+
+     Date Time     | Type |    Lunch     |     Position     | Source | Pair | Work Gap
+----------------------------------------------------------------------------------------
+→ 2025-12-19 08:55 |   in | lunch  0 min | Remote           |  cli   |   1  |
+             09:37 |  out | lunch  0 min | Remote           |  cli   |   1  |
+             13:07 |   in | lunch  0 min | Remote           |  cli   |   2  |
+             18:27 |  out | lunch 30 min | Remote           |  cli   |   2  |
+```
+
+### 🏖️ Holiday days
+
+Days marked as **Holiday**:
+
+- display no time values (--:--)
+- do not affect surplus calculations
+- are rendered as neutral rows
+
+### ➕ Period total
+
+At the end of the output, a cumulative total is always displayed:
+
+```text
+Σ Total ΔWORK: +02h04m
+```
+
+The total accounts for:
+
+- lunch breaks
+- work gaps
+- holidays (neutral contribution)
+
+### 🔢 JSON output (--json)
+
+```bash
+rtimelogger list --period 2025-12 --json
+```
+Outputs the data in JSON format for easy integration with other tools or scripts.
 
 ---
 

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -654,7 +654,7 @@ fn print_daily_row_compact(
 
     if day_position == Location::Holiday {
         println!(
-            "{:<dw$} | {}{:<12}{}\x1b[0m | {:<21} | {:^5} | {}{}{}\x1b[0m",
+            "{:<dw$} | {}{:<12}{}\x1b[0m | {:<21} | {:^5} | {}Δ -{}\x1b[0m",
             date_str,
             pos_color,
             pos_label,
@@ -662,7 +662,6 @@ fn print_daily_row_compact(
             format!("{}--:-- / --:-- / --:--{}", colors::GREY, colors::RESET),
             format!("{}--:--{}", colors::GREY, colors::RESET),
             colors::GREY,
-            "Δ -",
             colors::RESET,
             dw = dw
         );
@@ -716,16 +715,18 @@ fn print_daily_row_compact(
         }
     };
 
+    let times_string = format!("{} / {} / {}", first_in_str, lunch_str, end_str);
+    let delta_value = format!("Δ {}", delta_str);
     println!(
         "{:<dw$} | {}{:<12}{}\x1b[0m | {:<21} | {:^5} | {}{}{}\x1b[0m",
         date_str,
         pos_color,
         pos_label,
         colors::RESET,
-        format!("{} / {} / {}", first_in_str, lunch_str, end_str),
+        times_string,
         target_end_str,
         delta_color,
-        format!("Δ {}", delta_str),
+        delta_value,
         colors::RESET,
         dw = dw
     );

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -6,8 +6,11 @@ use crate::db::queries::load_events_by_date;
 use crate::errors::{AppError, AppResult};
 use crate::models::day_summary::DaySummary;
 use crate::models::event::Event;
+use crate::models::location::Location;
 use crate::ui::messages::{info, warning};
 use crate::utils::date::get_day_position;
+use crate::utils::formatting::FOOTER_INDENT;
+use crate::utils::table::{DAILY_TABLE_WIDTH, EVENTS_TABLE_WIDTH};
 use crate::utils::{colors, date, formatting, mins2readable};
 use chrono::{Datelike, NaiveDate};
 
@@ -21,6 +24,7 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
     } = cmd
     {
         let mut pool = DbPool::new(&cfg.database)?;
+        let show_wd = cfg.show_weekday.to_ascii_lowercase() != "n";
 
         // 1️⃣ Determina le date
         let dates = if *now {
@@ -54,8 +58,10 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
                 " {:^17} | {:^4} | {:^12} | {:^16} | {:^6} | {:^4} | {:^8}",
                 "Date Time", "Type", "Lunch", "Position", "Source", "Pair", "Work Gap"
             );
-            println!("{:-<88}", "-");
+            println!("{:-<etwidth$}", "-", etwidth = EVENTS_TABLE_WIDTH);
         }
+
+        let mut printed_daily_header = false;
 
         for d in dates {
             let d_str = d.to_string();
@@ -67,7 +73,12 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
             if let Some((ly, lm)) = last_month
                 && (ly, lm) != current_month
             {
-                println!("{:>108}", "--------------------------");
+                if show_wd {
+                    println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH);
+                } else {
+                    println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH - 4);
+                }
+                print_daily_table_header(cfg);
             }
             last_month = Some(current_month);
 
@@ -91,6 +102,11 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
             }
 
             // 5️⃣ Print daily row using timeline
+            if !printed_daily_header {
+                print_daily_table_header(cfg);
+                printed_daily_header = true;
+            }
+
             if let Some(day_surplus) = print_daily_row(&parsed_date, &events, &day_summary, cfg) {
                 total_surplus += day_surplus;
             }
@@ -105,14 +121,32 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
 
         // 7️⃣ Totale finale
         if any_output && !*events_only {
-            println!("{:>108}", "--------------------------");
+            // separatore coerente con header tabella daily (adegua se hai cambiato la larghezza)
+            let mut etwidth = FOOTER_INDENT;
+            if show_wd {
+                println!("{:-<twidth$}", "-", twidth = etwidth + 2);
+            } else {
+                println!("{:-<twidth$}", "-", twidth = etwidth - 2);
+                etwidth -= 2;
+            }
 
             let color = colors::color_for_surplus(total_surplus);
-            let formatted = mins2readable(total_surplus, false, false);
+            let delta = format_delta_compact(total_surplus);
 
+            // Plain (no ANSI) used ONLY for alignment length calculation
+            let footer_plain = format!("Σ Total ΔWORK: {}", delta);
+            let footer_styled = format!("Σ Total ΔWORK: {} {}{}", colors::RESET, color, delta);
+
+            // Compute padding so footer ends at the right edge of the table
+            let prefix = formatting::right_pad_prefix(etwidth, &footer_plain);
+
+            // Footer “section bar” + valore colorato
             println!(
-                "{:>116}",
-                format!("Σ Total surplus: {}{}{}", color, formatted, colors::RESET)
+                "{}{} {}{}",
+                prefix,
+                colors::SECTION_BAR,
+                footer_styled,
+                colors::RESET
             );
         }
 
@@ -267,80 +301,102 @@ fn print_daily_row(
         return None;
     }
 
-    let first_in = timeline.pairs[0].in_event.timestamp();
-    let first_in_str = first_in.format("%H:%M").to_string();
-
-    let last_out_opt = timeline
-        .pairs
-        .iter()
-        .filter_map(|p| p.out_event.as_ref())
-        .map(|ev| ev.timestamp())
-        .next_back();
-
     // Position of the day
     let day_position = get_day_position(timeline);
 
-    // Lunch total
-    let mut lunch_total: i64 = timeline.pairs.iter().map(|p| p.lunch_minutes).sum();
-    if lunch_total == 0 {
-        lunch_total = events.iter().map(|ev| ev.lunch.unwrap_or(0) as i64).sum();
-    }
-
-    // Expected exit timestamp: first_in + expected_minutes (min_work_duration + lunch)
-    let expected_exit = first_in + chrono::Duration::minutes(summary.expected);
-    let expected_exit_str = expected_exit.format("%H:%M").to_string();
-
-    // Weekday formatting
+    let date_str = date.to_string();
     let wd_type = cfg
         .show_weekday
         .chars()
         .next()
         .unwrap_or('m')
         .to_ascii_lowercase();
-    let weekday = date::weekday_str(&date.to_string(), wd_type);
+    let weekday = date::weekday_str(&date_str, wd_type);
 
-    let date_shown = format!("{} ({})", date, weekday);
     let pos_label = day_position.label();
     let pos_color = day_position.color();
     let pos_fmt = formatting::pad_right(pos_label, 16);
 
-    // Lunch
-    let lunch_str = if lunch_total > 0 {
-        crate::utils::time::format_minutes(lunch_total)
-    } else {
-        "--:--".to_string()
-    };
-    let lunch_c = colors::colorize_optional(&lunch_str);
+    // Defaults (Holiday / N/A)
+    let grey_time = format!("{}--:--{}", colors::GREY, colors::RESET);
 
-    // End
-    let end_str = last_out_opt
-        .map(|ts| ts.format("%H:%M").to_string())
-        .unwrap_or_else(|| "--:--".to_string());
-    let end_c = colors::colorize_optional(&end_str);
+    let mut first_in_str = grey_time.clone();
+    let mut lunch_c = grey_time.clone();
+    let mut end_c = grey_time.clone();
+    let mut expected_exit_str = grey_time.clone();
 
-    // Surplus
-    let non_work_gap_minutes: i64 = timeline
-        .gaps
-        .iter()
-        .filter(|g| !g.is_work_gap)
-        .map(|g| g.duration_minutes)
-        .sum();
+    let mut surplus_opt: Option<i64> = Some(0); // Holiday contributes 0
+    let mut surplus_display = "-".to_string();
+    let mut surplus_color = colors::GREY;
 
-    let surplus_opt =
-        last_out_opt.map(|out| (out - expected_exit).num_minutes() - non_work_gap_minutes);
+    if day_position != Location::Holiday {
+        let first_in = timeline.pairs[0].in_event.timestamp();
+        first_in_str = first_in.format("%H:%M").to_string();
 
-    let (surplus_str, surplus_color) = match surplus_opt {
-        None => ("-".to_string(), colors::GREY),
-        Some(0) => ("0".to_string(), colors::GREY),
-        Some(v) => {
-            let color = colors::color_for_surplus(v);
-            (format!("{:+}", v), color)
+        let last_out_opt = timeline
+            .pairs
+            .iter()
+            .filter_map(|p| p.out_event.as_ref())
+            .map(|ev| ev.timestamp())
+            .next_back();
+
+        // Lunch total
+        let mut lunch_total: i64 = timeline.pairs.iter().map(|p| p.lunch_minutes).sum();
+        if lunch_total == 0 {
+            lunch_total = events.iter().map(|ev| ev.lunch.unwrap_or(0) as i64).sum();
         }
-    };
+
+        // Expected exit timestamp
+        let expected_exit = first_in + chrono::Duration::minutes(summary.expected);
+        expected_exit_str = expected_exit.format("%H:%M").to_string();
+
+        // Lunch
+        let lunch_str = if lunch_total > 0 {
+            crate::utils::time::format_minutes(lunch_total)
+        } else {
+            "--:--".to_string()
+        };
+        lunch_c = colors::colorize_optional(&lunch_str);
+
+        // End
+        let end_str = last_out_opt
+            .map(|ts| ts.format("%H:%M").to_string())
+            .unwrap_or_else(|| "--:--".to_string());
+        end_c = colors::colorize_optional(&end_str);
+
+        // Surplus (worked)
+        let non_work_gap_minutes: i64 = timeline
+            .gaps
+            .iter()
+            .filter(|g| !g.is_work_gap)
+            .map(|g| g.duration_minutes)
+            .sum();
+
+        surplus_opt =
+            last_out_opt.map(|out| (out - expected_exit).num_minutes() - non_work_gap_minutes);
+
+        match surplus_opt {
+            None => {
+                surplus_display = "-".to_string();
+                surplus_color = colors::GREY;
+            }
+            Some(0) => {
+                surplus_display = "0".to_string();
+                surplus_color = colors::GREY;
+            }
+            Some(v) => {
+                let abs = mins2readable(v.abs(), false, false); // "02h 04m"
+                let compact = abs.replace(' ', ""); // "02h04m"
+                surplus_display = format!("{}{}", if v < 0 { "-" } else { "+" }, compact);
+                surplus_color = colors::color_for_surplus(v);
+            }
+        }
+    }
 
     println!(
-        "{} | {}{}\x1b[0m | Start {:^5} | Lunch {:^5} | End {:^5} | Expected {:^5} | Surplus {}{:>5} min\x1b[0m",
-        date_shown,
+        " {:^10} | {:^2} | {}{}\x1b[0m | {:^5} | {:^5} | {:^5} | {:^5} | {}{:>7}\x1b[0m",
+        date_str,
+        weekday,
         pos_color,
         pos_fmt,
         first_in_str,
@@ -348,7 +404,7 @@ fn print_daily_row(
         end_c,
         expected_exit_str,
         surplus_color,
-        surplus_str,
+        surplus_display
     );
 
     surplus_opt
@@ -361,35 +417,80 @@ fn print_daily_row(
 //
 
 fn print_details(summary: &DaySummary) {
-    println!("    Details:");
+    // Se non ci sono pair, non stampo dettagli
+    if summary.timeline.pairs.is_empty() {
+        return;
+    }
+
+    println!();
+    println!("    {} DETAILS {}", colors::SECTION_BAR, colors::RESET);
+    println!(
+        "    {:^4} | {:^5} | {:^5} | {:^6} | {:^5} | {:^16} | {:^2}",
+        "PAIR", "IN", "OUT", "WORKED", "LUNCH", "POSITION", "WG"
+    );
+    println!("    {:-<72}", "-");
+
     for (idx, p) in summary.timeline.pairs.iter().enumerate() {
-        let in_t = p.in_event.timestamp().format("%H:%M");
-        let in_c = colors::colorize_in_out(&in_t.to_string(), true);
+        let in_t = p.in_event.timestamp().format("%H:%M").to_string();
+        let in_c = colors::colorize_in_out(&in_t, true);
 
         let out_t = p
             .out_event
             .as_ref()
             .map(|ev| ev.timestamp().format("%H:%M").to_string())
-            .unwrap_or("--:--".to_string());
+            .unwrap_or_else(|| "--:--".to_string());
         let out_c = colors::colorize_in_out(&out_t, false);
 
-        let worked = colors::colorize_optional(&mins2readable(p.duration_minutes, false, false));
-        let lunch = colors::colorize_optional(&format!("{:>2} min", p.lunch_minutes));
+        // WORKED: già in formato leggibile. Lo compatto senza spazi (es: "02h04m") per stabilità colonne.
+        let worked_raw = mins2readable(p.duration_minutes, false, false); // "00h 42m"
+        let worked_compact = worked_raw.replace(' ', ""); // "00h42m"
+        let worked_c = colors::colorize_optional(&worked_compact);
+
+        // LUNCH: compatto "30m"
+        let lunch_compact = format!("{:>2}m", p.lunch_minutes);
+        let lunch_c = colors::colorize_optional(&lunch_compact);
+
         let pos_label = p.position.label();
         let pos_color = p.position.color();
         let pos_fmt = formatting::pad_right(pos_label, 16);
 
+        let wg_str = if p.work_gap { "Y" } else { "" };
+
         println!(
-            "      Pair {:>2}: IN {:^5} | OUT {:^5} | worked {:^7} | lunch {} | {}{}\x1b[0m | {}",
+            "    {:>4} | {:^5} | {:^5} | {:^6} | {:^5} | {}{}\x1b[0m | {:^2}",
             idx + 1,
             in_c,
             out_c,
-            worked,
-            lunch,
+            worked_c,
+            lunch_c,
             pos_color,
             pos_fmt,
-            if p.work_gap { "YES" } else { "" }
+            wg_str
         );
     }
+
     println!();
+}
+
+fn print_daily_table_header(cfg: &Config) {
+    // Weekday column is optional in your config; if disabled, keep header consistent with output
+    let show_wd = cfg.show_weekday.to_ascii_lowercase() != "n"; // adattala se "n" non è il tuo flag
+    if show_wd {
+        println!(
+            " {:^10} | {:^2} | {:^16} | {:^5} | {:^5} | {:^5} | {:^5} | {:^7}",
+            "DATE", "WD", "POSITION", "IN", "LNCH", "OUT", "TGT", "ΔWORK"
+        );
+        println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH);
+    } else {
+        println!(
+            " {:^10} | {:^16} | {:^5} | {:^5} | {:^5} | {:^5} | {:^7}",
+            "DATE", "POSITION", "IN", "LNCH", "OUT", "TGT", "ΔWORK"
+        );
+        println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH - 4);
+    }
+}
+
+fn format_delta_compact(minutes: i64) -> String {
+    let abs = mins2readable(minutes.abs(), false, true); // es: "02h 04m"
+    format!("{}{}", if minutes < 0 { "-" } else { "+" }, abs)
 }

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -9,13 +9,118 @@ use crate::models::event::Event;
 use crate::models::location::Location;
 use crate::ui::messages::{info, warning};
 use crate::utils::date::get_day_position;
-use crate::utils::formatting::FOOTER_INDENT;
-use crate::utils::table::{DAILY_TABLE_WIDTH, EVENTS_TABLE_WIDTH};
+use crate::utils::table::EVENTS_TABLE_WIDTH;
 use crate::utils::{colors, date, formatting, mins2readable};
 use chrono::{Datelike, NaiveDate};
 
+//
+// ───────────────────────────────────────────────────────────────────────────────
+// Local Enums and Layout
+// ───────────────────────────────────────────────────────────────────────────────
+//
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WeekdayMode {
+    None,
+    Short,
+    Medium,
+    Long,
+}
+
+fn weekday_mode(cfg: &Config) -> WeekdayMode {
+    match cfg.show_weekday.to_ascii_lowercase().as_str() {
+        "none" => WeekdayMode::None,
+        "short" => WeekdayMode::Short,
+        "medium" => WeekdayMode::Medium,
+        "long" => WeekdayMode::Long,
+        // fallback conservativo
+        _ => WeekdayMode::Medium,
+    }
+}
+
+fn weekday_type_char(mode: WeekdayMode) -> Option<char> {
+    match mode {
+        WeekdayMode::None => None,
+        WeekdayMode::Short => Some('s'),
+        WeekdayMode::Medium => Some('m'),
+        WeekdayMode::Long => Some('l'),
+    }
+}
+
+/// Nel compact: se weekday abilitato, forza sempre Short (2 lettere) per mantenere layout stabile.
+fn effective_weekday_mode(mode: WeekdayMode, compact: bool) -> WeekdayMode {
+    if !compact {
+        return mode;
+    }
+    match mode {
+        WeekdayMode::None => WeekdayMode::None,
+        _ => WeekdayMode::Short,
+    }
+}
+
+/// Larghezza della colonna DATE in base al weekday.
+/// - None:   "YYYY-MM-DD"               = 10
+/// - Short:  "YYYY-MM-DD (Fr)"          = 15
+/// - Medium: "YYYY-MM-DD (Fri)"         = 16
+/// - Long:   "YYYY-MM-DD (Wednesday)"   = 22 (max 9 chars weekday)
+fn date_col_width(mode: WeekdayMode) -> usize {
+    match mode {
+        WeekdayMode::None => 10,
+        WeekdayMode::Short => 15,
+        WeekdayMode::Medium => 16,
+        WeekdayMode::Long => 22,
+    }
+}
+
+// Column widths (daily standard table)
+const POS_W: usize = 16;
+const TIME_W: usize = 5; // IN / LNCH / OUT / TGT
+const DWORK_W: usize = 7;
+
+/// Daily table total width, computed from column widths.
+/// Format used:
+/// " {DATE} | {POSITION} | {IN} | {LNCH} | {OUT} | {TGT} | {ΔWORK}"
+fn daily_table_width(mode: WeekdayMode) -> usize {
+    let dw = date_col_width(mode);
+    // 1 leading space + cols + separators (" | " = 3 chars) between 7 columns
+    // Total = 1 + date + 3 + pos + 3 + in + 3 + lnch + 3 + out + 3 + tgt + 3 + dwork
+    1 + dw + 3 + POS_W + 3 + TIME_W + 3 + TIME_W + 3 + TIME_W + 3 + TIME_W + 3 + DWORK_W + 1
+}
+
+// Compact table widths
+const CPOS_W: usize = 12;
+const TRIPLE_W: usize = 21; // "IN / LNCH / OUT"
+const CTGT_W: usize = 5;
+const CDWORK_W: usize = 7;
+
+/// Compact table total width.
+/// Format used:
+/// "{DATE} | {POSITION} | {IN/LNCH/OUT} | {TGT} | {ΔWORK}"
+fn compact_table_width(mode: WeekdayMode) -> usize {
+    let dw = date_col_width(mode);
+    // date + 3 + pos + 3 + triple + 3 + tgt + 3 + dwork
+    dw + 3 + CPOS_W + 3 + TRIPLE_W + 3 + CTGT_W + 3 + CDWORK_W + 3
+}
+
+fn format_date_with_weekday(date: &NaiveDate, mode: WeekdayMode) -> String {
+    let date_str = date.to_string();
+    if let Some(ch) = weekday_type_char(mode) {
+        let wd = date::weekday_str(&date_str, ch);
+        format!("{} ({})", date_str, wd)
+    } else {
+        date_str
+    }
+}
+
+//
+// ───────────────────────────────────────────────────────────────────────────────
+// Public entry
+// ───────────────────────────────────────────────────────────────────────────────
+//
+
 pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
     if let Commands::List {
+        compact,
         period,
         now,
         details,
@@ -23,10 +128,17 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
         ..
     } = cmd
     {
-        let mut pool = DbPool::new(&cfg.database)?;
-        let show_wd = cfg.show_weekday.to_ascii_lowercase() != "n";
+        if *compact && *details {
+            return Err(AppError::InvalidArgs(
+                "--compact cannot be used together with --details.".into(),
+            ));
+        }
 
-        // 1️⃣ Determina le date
+        let mut pool = DbPool::new(&cfg.database)?;
+        let wd_mode_cfg = weekday_mode(cfg);
+        let wd_mode = effective_weekday_mode(wd_mode_cfg, *compact);
+
+        // 1️⃣ Determine dates
         let dates = if *now {
             vec![date::today()]
         } else {
@@ -38,7 +150,7 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
             return Ok(());
         }
 
-        // 2️⃣ Stampa intestazione se non in modalità --now
+        // 2️⃣ Header (only if not --now)
         if !*now {
             if period.is_some() {
                 print_header(period);
@@ -49,8 +161,12 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
 
         let mut total_surplus: i64 = 0;
         let mut any_output = false;
-        let mut last_month: Option<(i32, u32)> = None;
 
+        // Month separator state (only for daily summaries)
+        let mut last_month: Option<(i32, u32)> = None;
+        let mut printed_daily_header = false;
+
+        // EVENTS header if requested
         if *events_only && Event::has_events_for_dates(&mut pool, &dates)? {
             println!("EVENTS:");
             println!();
@@ -58,32 +174,36 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
                 " {:^17} | {:^4} | {:^12} | {:^16} | {:^6} | {:^4} | {:^8}",
                 "Date Time", "Type", "Lunch", "Position", "Source", "Pair", "Work Gap"
             );
-            println!("{:-<etwidth$}", "-", etwidth = EVENTS_TABLE_WIDTH);
+            println!("{:-<w$}", "-", w = EVENTS_TABLE_WIDTH);
         }
 
-        let mut printed_daily_header = false;
+        for day in dates {
+            // Month separator (daily summaries only)
+            if !*events_only {
+                let current_month = (day.year(), day.month());
+                if let Some((ly, lm)) = last_month
+                    && (ly, lm) != current_month
+                {
+                    let twidth = if *compact {
+                        compact_table_width(wd_mode)
+                    } else {
+                        daily_table_width(wd_mode)
+                    };
+                    println!("{:-<w$}", "-", w = twidth);
 
-        for d in dates {
-            let d_str = d.to_string();
-            let parsed_date = NaiveDate::parse_from_str(&d_str, "%Y-%m-%d")
-                .map_err(|_| AppError::InvalidDate(d_str))?;
-
-            // 🧨 Month separator
-            let current_month = (parsed_date.year(), parsed_date.month());
-            if let Some((ly, lm)) = last_month
-                && (ly, lm) != current_month
-            {
-                if show_wd {
-                    println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH);
-                } else {
-                    println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH - 4);
+                    // reprint table header at month boundary
+                    if *compact {
+                        print_compact_header(wd_mode);
+                    } else {
+                        print_daily_table_header(wd_mode);
+                    }
+                    printed_daily_header = true;
                 }
-                print_daily_table_header(cfg);
+                last_month = Some(current_month);
             }
-            last_month = Some(current_month);
 
-            // 3️⃣ Load events for date
-            let events = load_events_by_date(&mut pool, &parsed_date)?;
+            // Load events
+            let events = load_events_by_date(&mut pool, &day)?;
             if events.is_empty() {
                 continue;
             }
@@ -93,25 +213,35 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
                 continue;
             }
 
-            // 4️⃣ Build summary
+            // Build summary
             let day_summary = Core::build_daily_summary(&events, cfg);
-
             if day_summary.timeline.pairs.is_empty() {
-                info(format!("No valid pairs for {}.", parsed_date));
+                info(format!("No valid pairs for {}.", day));
                 continue;
             }
 
-            // 5️⃣ Print daily row using timeline
+            // Print header once
             if !printed_daily_header {
-                print_daily_table_header(cfg);
+                if *compact {
+                    print_compact_header(wd_mode);
+                } else {
+                    print_daily_table_header(wd_mode);
+                }
                 printed_daily_header = true;
             }
 
-            if let Some(day_surplus) = print_daily_row(&parsed_date, &events, &day_summary, cfg) {
-                total_surplus += day_surplus;
+            // Print row
+            let day_surplus = if *compact {
+                print_daily_row_compact(&day, &events, &day_summary, cfg, wd_mode)
+            } else {
+                print_daily_row(&day, &events, &day_summary, cfg, wd_mode)
+            };
+
+            if let Some(v) = day_surplus {
+                total_surplus += v;
             }
 
-            // 6️⃣ Optional details
+            // Optional details (not allowed in compact)
             if *details && (*now || period.as_ref().is_some_and(|p| p.len() == 10)) {
                 print_details(&day_summary);
             }
@@ -119,35 +249,44 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
             any_output = true;
         }
 
-        // 7️⃣ Totale finale
+        // Footer total
         if any_output && !*events_only {
-            // separatore coerente con header tabella daily (adegua se hai cambiato la larghezza)
-            let mut etwidth = FOOTER_INDENT;
-            if show_wd {
-                println!("{:-<twidth$}", "-", twidth = etwidth + 2);
+            let twidth = if *compact {
+                compact_table_width(wd_mode)
             } else {
-                println!("{:-<twidth$}", "-", twidth = etwidth - 2);
-                etwidth -= 2;
-            }
+                daily_table_width(wd_mode)
+            };
+            println!("{:-<w$}", "-", w = twidth);
 
             let color = colors::color_for_surplus(total_surplus);
             let delta = format_delta_compact(total_surplus);
 
-            // Plain (no ANSI) used ONLY for alignment length calculation
+            // background (SECTION_BAR) only on label
             let footer_plain = format!("Σ Total ΔWORK: {}", delta);
-            let footer_styled = format!("Σ Total ΔWORK: {} {}{}", colors::RESET, color, delta);
-
-            // Compute padding so footer ends at the right edge of the table
-            let prefix = formatting::right_pad_prefix(etwidth, &footer_plain);
-
-            // Footer “section bar” + valore colorato
-            println!(
-                "{}{} {}{}",
-                prefix,
-                colors::SECTION_BAR,
-                footer_styled,
-                colors::RESET
+            let prefix = formatting::right_pad_prefix(
+                twidth.saturating_sub(if *compact { 1 } else { 3 }),
+                &footer_plain,
             );
+
+            if *compact {
+                println!(
+                    "{}Σ Total ΔWORK: {}{}{}",
+                    prefix,
+                    color,
+                    delta,
+                    colors::RESET
+                );
+            } else {
+                println!(
+                    "{}{} Σ Total ΔWORK: {} {}{}{}",
+                    prefix,
+                    colors::SECTION_BAR, // background ON (label)
+                    colors::RESET,       // background OFF
+                    color,               // value color
+                    delta,               // value
+                    colors::RESET        // final reset
+                );
+            }
         }
 
         Ok(())
@@ -158,13 +297,11 @@ pub fn handle(cmd: &Commands, cfg: &Config) -> AppResult<()> {
 
 //
 // ───────────────────────────────────────────────────────────────────────────────
-// Helper: Resolve period → Vec<NaiveDate>
+// Period resolver
 // ───────────────────────────────────────────────────────────────────────────────
 //
 
 fn resolve_period(period: &Option<String>) -> AppResult<Vec<NaiveDate>> {
-    use crate::errors::AppError;
-
     if let Some(p) = period {
         if p == "all" {
             return date::generate_all_dates().map_err(AppError::InvalidDate);
@@ -199,13 +336,10 @@ fn print_header(period: &Option<String>) {
             ));
             return;
         }
+
         match p.len() {
-            4 => {
-                // header for year
-                info(format!("📅 Saved sessions for year {}\n", p));
-            }
+            4 => info(format!("📅 Saved sessions for year {}\n", p)),
             7 => {
-                // header for month
                 let parts: Vec<&str> = p.split('-').collect();
                 if parts.len() == 2 {
                     info(format!(
@@ -215,12 +349,8 @@ fn print_header(period: &Option<String>) {
                     ));
                 }
             }
-            10 => {
-                // header for single date
-                info(format!("📅 Saved session for date {}\n", p));
-            }
+            10 => info(format!("📅 Saved session for date {}\n", p)),
             15 => {
-                // header for period between two dates
                 let parts: Vec<&str> = p.split(':').collect();
                 if parts.len() == 2 {
                     info(format!(
@@ -233,9 +363,10 @@ fn print_header(period: &Option<String>) {
         }
     }
 }
+
 //
 // ───────────────────────────────────────────────────────────────────────────────
-// Modalità list --events
+// list --events
 // ───────────────────────────────────────────────────────────────────────────────
 //
 
@@ -243,28 +374,21 @@ fn print_raw_events(events: &[Event]) {
     let mut last_date: Option<String> = None;
 
     for ev in events {
-        //eprintln!("event: {:?}", ev);
         let lunch = colors::colorize_optional(&format!("{:>2} min", ev.lunch.unwrap_or(0)));
         let pos_label = ev.location.label();
         let pos_color = ev.location.color();
-        let pos_fmt = formatting::pad_right(pos_label, 16);
+        let pos_fmt = formatting::pad_right(pos_label, POS_W);
 
         let (dash, date_str) = if ev.kind.is_in() {
-            let current_date = ev.date_str(); // String stabile
-
+            let current_date = ev.date_str();
             match &last_date {
-                Some(d) if d == &current_date => {
-                    // stesso giorno → niente freccia, niente data
-                    (" ", " ".repeat(10))
-                }
+                Some(d) if d == &current_date => (" ", " ".repeat(10)),
                 _ => {
-                    // nuovo giorno → freccia + data
                     last_date = Some(current_date.clone());
                     ("→", current_date)
                 }
             }
         } else {
-            // OUT → mai freccia, mai data
             (" ", " ".repeat(10))
         };
 
@@ -286,45 +410,57 @@ fn print_raw_events(events: &[Event]) {
 
 //
 // ───────────────────────────────────────────────────────────────────────────────
-// Daily row (the core of the command)
+// Daily standard table
 // ───────────────────────────────────────────────────────────────────────────────
 //
+
+fn print_daily_table_header(wd_mode: WeekdayMode) {
+    let dw = date_col_width(wd_mode);
+    let twidth = daily_table_width(wd_mode);
+
+    println!(
+        " {:^dw$} | {:^16} | {:^5} | {:^5} | {:^5} | {:^5} | {:^7}",
+        "DATE",
+        "POSITION",
+        "IN",
+        "LNCH",
+        "OUT",
+        "TGT",
+        "ΔWORK",
+        dw = dw
+    );
+
+    println!("{:-<w$}", "-", w = twidth);
+}
 
 fn print_daily_row(
     date: &NaiveDate,
     events: &[Event],
     summary: &DaySummary,
-    cfg: &Config,
+    _cfg: &Config,
+    wd_mode: WeekdayMode,
 ) -> Option<i64> {
     let timeline = &summary.timeline;
     if timeline.pairs.is_empty() {
         return None;
     }
 
-    // Position of the day
     let day_position = get_day_position(timeline);
-
-    let date_str = date.to_string();
-    let wd_type = cfg
-        .show_weekday
-        .chars()
-        .next()
-        .unwrap_or('m')
-        .to_ascii_lowercase();
-    let weekday = date::weekday_str(&date_str, wd_type);
+    let date_str = format_date_with_weekday(date, wd_mode);
+    let dw = date_col_width(wd_mode);
 
     let pos_label = day_position.label();
     let pos_color = day_position.color();
-    let pos_fmt = formatting::pad_right(pos_label, 16);
+    let pos_fmt = formatting::pad_right(pos_label, POS_W);
 
     // Defaults (Holiday / N/A)
     let grey_time = format!("{}--:--{}", colors::GREY, colors::RESET);
-
     let mut first_in_str = grey_time.clone();
     let mut lunch_c = grey_time.clone();
     let mut end_c = grey_time.clone();
     let mut expected_exit_str = grey_time.clone();
 
+    // Defaults for surplus
     let mut surplus_opt: Option<i64> = Some(0); // Holiday contributes 0
     let mut surplus_display = "-".to_string();
     let mut surplus_color = colors::GREY;
@@ -346,7 +482,7 @@ fn print_daily_row(
             lunch_total = events.iter().map(|ev| ev.lunch.unwrap_or(0) as i64).sum();
         }
 
-        // Expected exit timestamp
+        // Target end
         let expected_exit = first_in + chrono::Duration::minutes(summary.expected);
         expected_exit_str = expected_exit.format("%H:%M").to_string();
 
@@ -394,9 +530,8 @@ fn print_daily_row(
     }
 
     println!(
-        " {:^10} | {:^2} | {}{}\x1b[0m | {:^5} | {:^5} | {:^5} | {:^5} | {}{:>7}\x1b[0m",
+        " {:<dw$} | {}{}\x1b[0m | {:^5} | {:^5} | {:^5} | {:^5} | {}{:>7}\x1b[0m",
         date_str,
-        weekday,
         pos_color,
         pos_fmt,
         first_in_str,
@@ -404,7 +539,8 @@ fn print_daily_row(
         end_c,
         expected_exit_str,
         surplus_color,
-        surplus_display
+        surplus_display,
+        dw = dw
     );
 
     surplus_opt
@@ -417,7 +553,6 @@ fn print_daily_row(
 //
 
 fn print_details(summary: &DaySummary) {
-    // Se non ci sono pair, non stampo dettagli
     if summary.timeline.pairs.is_empty() {
         return;
     }
@@ -441,18 +576,16 @@ fn print_details(summary: &DaySummary) {
             .unwrap_or_else(|| "--:--".to_string());
         let out_c = colors::colorize_in_out(&out_t, false);
 
-        // WORKED: già in formato leggibile. Lo compatto senza spazi (es: "02h04m") per stabilità colonne.
-        let worked_raw = mins2readable(p.duration_minutes, false, false); // "00h 42m"
-        let worked_compact = worked_raw.replace(' ', ""); // "00h42m"
+        let worked_raw = mins2readable(p.duration_minutes, false, false);
+        let worked_compact = worked_raw.replace(' ', "");
         let worked_c = colors::colorize_optional(&worked_compact);
 
-        // LUNCH: compatto "30m"
         let lunch_compact = format!("{:>2}m", p.lunch_minutes);
         let lunch_c = colors::colorize_optional(&lunch_compact);
 
         let pos_label = p.position.label();
         let pos_color = p.position.color();
-        let pos_fmt = formatting::pad_right(pos_label, 16);
+        let pos_fmt = formatting::pad_right(pos_label, POS_W);
 
         let wg_str = if p.work_gap { "Y" } else { "" };
 
@@ -472,25 +605,130 @@ fn print_details(summary: &DaySummary) {
     println!();
 }
 
-fn print_daily_table_header(cfg: &Config) {
-    // Weekday column is optional in your config; if disabled, keep header consistent with output
-    let show_wd = cfg.show_weekday.to_ascii_lowercase() != "n"; // adattala se "n" non è il tuo flag
-    if show_wd {
-        println!(
-            " {:^10} | {:^2} | {:^16} | {:^5} | {:^5} | {:^5} | {:^5} | {:^7}",
-            "DATE", "WD", "POSITION", "IN", "LNCH", "OUT", "TGT", "ΔWORK"
-        );
-        println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH);
-    } else {
-        println!(
-            " {:^10} | {:^16} | {:^5} | {:^5} | {:^5} | {:^5} | {:^7}",
-            "DATE", "POSITION", "IN", "LNCH", "OUT", "TGT", "ΔWORK"
-        );
-        println!("{:-<twidth$}", "-", twidth = DAILY_TABLE_WIDTH - 4);
-    }
+//
+// ───────────────────────────────────────────────────────────────────────────────
+// Compact table
+// ───────────────────────────────────────────────────────────────────────────────
+//
+
+fn print_compact_header(wd_mode: WeekdayMode) {
+    let dw = date_col_width(wd_mode);
+    let twidth = compact_table_width(wd_mode);
+
+    println!(
+        "{:^dw$} | {:^12} | {:^21} | {:^5} | {:^7}",
+        "DATE",
+        "POSITION",
+        "IN / LNCH / OUT",
+        "TGT",
+        "ΔWORK",
+        dw = dw
+    );
+
+    println!("{:-<w$}", "-", w = twidth);
 }
 
 fn format_delta_compact(minutes: i64) -> String {
-    let abs = mins2readable(minutes.abs(), false, true); // es: "02h 04m"
+    let abs = mins2readable(minutes.abs(), false, true); // già compatto
     format!("{}{}", if minutes < 0 { "-" } else { "+" }, abs)
+}
+
+fn print_daily_row_compact(
+    date: &NaiveDate,
+    events: &[Event],
+    summary: &DaySummary,
+    _cfg: &Config,
+    wd_mode: WeekdayMode,
+) -> Option<i64> {
+    let timeline = &summary.timeline;
+    if timeline.pairs.is_empty() {
+        return None;
+    }
+
+    let dw = date_col_width(wd_mode);
+    let date_str = format_date_with_weekday(date, wd_mode);
+
+    let day_position = get_day_position(timeline);
+    let pos_label = day_position.label();
+    let pos_color = day_position.color();
+
+    if day_position == Location::Holiday {
+        println!(
+            "{:<dw$} | {}{:<12}{}\x1b[0m | {:<21} | {:^5} | {}{}{}\x1b[0m",
+            date_str,
+            pos_color,
+            pos_label,
+            colors::RESET,
+            format!("{}--:-- / --:-- / --:--{}", colors::GREY, colors::RESET),
+            format!("{}--:--{}", colors::GREY, colors::RESET),
+            colors::GREY,
+            "Δ -",
+            colors::RESET,
+            dw = dw
+        );
+        return Some(0);
+    }
+
+    let first_in = timeline.pairs[0].in_event.timestamp();
+    let first_in_str = first_in.format("%H:%M").to_string();
+
+    let last_out_opt = timeline
+        .pairs
+        .iter()
+        .filter_map(|p| p.out_event.as_ref())
+        .map(|ev| ev.timestamp())
+        .next_back();
+
+    let end_str = last_out_opt
+        .map(|ts| ts.format("%H:%M").to_string())
+        .unwrap_or_else(|| "--:--".to_string());
+
+    let mut lunch_total: i64 = timeline.pairs.iter().map(|p| p.lunch_minutes).sum();
+    if lunch_total == 0 {
+        lunch_total = events.iter().map(|ev| ev.lunch.unwrap_or(0) as i64).sum();
+    }
+    let lunch_str = if lunch_total > 0 {
+        crate::utils::time::format_minutes(lunch_total)
+    } else {
+        "--:--".to_string()
+    };
+
+    let expected_exit = first_in + chrono::Duration::minutes(summary.expected);
+    let target_end_str = expected_exit.format("%H:%M").to_string();
+
+    let non_work_gap_minutes: i64 = timeline
+        .gaps
+        .iter()
+        .filter(|g| !g.is_work_gap)
+        .map(|g| g.duration_minutes)
+        .sum();
+
+    let surplus_opt =
+        last_out_opt.map(|out| (out - expected_exit).num_minutes() - non_work_gap_minutes);
+
+    let (delta_str, delta_color) = match surplus_opt {
+        None => ("-".to_string(), colors::GREY),
+        Some(0) => ("0".to_string(), colors::GREY),
+        Some(v) => {
+            let abs = mins2readable(v.abs(), false, true);
+            let sign = if v < 0 { "-" } else { "+" };
+            (format!("{}{}", sign, abs), colors::color_for_surplus(v))
+        }
+    };
+
+    println!(
+        "{:<dw$} | {}{:<12}{}\x1b[0m | {:<21} | {:^5} | {}{}{}\x1b[0m",
+        date_str,
+        pos_color,
+        pos_label,
+        colors::RESET,
+        format!("{} / {} / {}", first_in_str, lunch_str, end_str),
+        target_end_str,
+        delta_color,
+        format!("Δ {}", delta_str),
+        colors::RESET,
+        dw = dw
+    );
+
+    surplus_opt
 }

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -136,6 +136,10 @@ pub enum Commands {
 
     /// List sessions
     List {
+        /// Compact output (single dense line per day)
+        #[arg(long, action = clap::ArgAction::SetTrue)]
+        compact: bool,
+
         #[arg(long, short, help = "Filter by year/month/day or a custom range")]
         period: Option<String>,
 
@@ -156,6 +160,7 @@ pub enum Commands {
 
         #[arg(long = "summary", help = "Show summarized per-pair rows")]
         summary: bool,
+
     },
 
     /// Create a backup copy of the database

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -78,10 +78,10 @@ pub enum Commands {
         /// Date of the event (YYYY-MM-DD)
         date: String,
 
-        /// Position (O = Office, R = Remote, H = Home, C = Client, M = Mixed)
+        /// Position (O = Office, R = Remote, H = Holiday, C = Client, M = Mixed)
         #[arg(
             long = "pos",
-            help = "Work position: O=Office, R=Remote, H=Home, C=Client, M=Mixed"
+            help = "Work position: O=Office, R=Remote, H=Holiday, C=Client, M=Mixed"
         )]
         pos: Option<String>,
 

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -157,10 +157,6 @@ pub enum Commands {
 
         #[arg(long = "pairs", help = "Filter by pair id (only with --events)")]
         pairs: Option<usize>,
-
-        #[arg(long = "summary", help = "Show summarized per-pair rows")]
-        summary: bool,
-
     },
 
     /// Create a backup copy of the database

--- a/src/core/add.rs
+++ b/src/core/add.rs
@@ -52,7 +52,7 @@ impl AddLogic {
         // ------------------------------------------------
         if edit_mode {
             let pair_num = edit_pair
-                .ok_or_else(|| AppError::InvalidTime("Missing --pair when using --edit.".into()))?;
+                .ok_or_else(|| AppError::InvalidArgs("Missing --pair when using --edit.".into()))?;
 
             let (mut ev_in, mut ev_out) = load_pair_by_index(&pool.conn, &date, pair_num)?;
 
@@ -167,7 +167,7 @@ impl AddLogic {
         if pos_final == Location::Holiday {
             // Holiday è un marker di giornata: non accetto parametri temporali o lunch/work-gap
             if start.is_some() || end.is_some() || lunch.is_some() || work_gap.is_some() {
-                return Err(AppError::InvalidTime(
+                return Err(AppError::InvalidArgs(
                     "For --pos H (Holiday) do not specify --in, --out, --lunch or --work-gap."
                         .into(),
                 ));
@@ -175,7 +175,7 @@ impl AddLogic {
 
             // Se ci sono già eventi quel giorno, non è coerente segnare ferie
             if has_events {
-                return Err(AppError::InvalidTime(
+                return Err(AppError::InvalidArgs(
                     "Cannot set Holiday on a date that already has events.".into(),
                 ));
             }
@@ -183,7 +183,7 @@ impl AddLogic {
             // Inserisco un evento sentinella a mezzanotte con location Holiday.
             // Uso EventType::In perché nel modello ci sono solo In/Out.
             let holiday_time = NaiveTime::from_hms_opt(0, 0, 0)
-                .ok_or_else(|| AppError::InvalidTime("Invalid holiday time sentinel.".into()))?;
+                .ok_or_else(|| AppError::Other("Invalid holiday time sentinel.".into()))?;
 
             let ev_holiday = Event::new(
                 0,
@@ -205,7 +205,7 @@ impl AddLogic {
         // CASE A: only lunch update
         if start.is_none() && end.is_none() && lunch.is_some() {
             if !has_events {
-                return Err(AppError::InvalidTime(
+                return Err(AppError::InvalidArgs(
                     "Cannot set lunch on a date with no events.".into(),
                 ));
             }
@@ -233,7 +233,7 @@ impl AddLogic {
 
         // CASE B: nothing to do
         if start.is_none() && end.is_none() {
-            return Err(AppError::InvalidTime(
+            return Err(AppError::InvalidArgs(
                 "Nothing to do: specify at least --in, --out or --lunch.".into(),
             ));
         }
@@ -334,7 +334,7 @@ impl AddLogic {
             return Ok(());
         }
 
-        Err(AppError::InvalidTime(
+        Err(AppError::InvalidArgs(
             "Unhandled combination of parameters.".into(),
         ))
     }

--- a/src/core/add.rs
+++ b/src/core/add.rs
@@ -161,6 +161,47 @@ impl AddLogic {
             ));
         }
 
+        // ------------------------------------------------
+        // ✅ CASE HOLIDAY: allow --pos H without --in/--out
+        // ------------------------------------------------
+        if pos_final == Location::Holiday {
+            // Holiday è un marker di giornata: non accetto parametri temporali o lunch/work-gap
+            if start.is_some() || end.is_some() || lunch.is_some() || work_gap.is_some() {
+                return Err(AppError::InvalidTime(
+                    "For --pos H (Holiday) do not specify --in, --out, --lunch or --work-gap."
+                        .into(),
+                ));
+            }
+
+            // Se ci sono già eventi quel giorno, non è coerente segnare ferie
+            if has_events {
+                return Err(AppError::InvalidTime(
+                    "Cannot set Holiday on a date that already has events.".into(),
+                ));
+            }
+
+            // Inserisco un evento sentinella a mezzanotte con location Holiday.
+            // Uso EventType::In perché nel modello ci sono solo In/Out.
+            let holiday_time = NaiveTime::from_hms_opt(0, 0, 0)
+                .ok_or_else(|| AppError::InvalidTime("Invalid holiday time sentinel.".into()))?;
+
+            let ev_holiday = Event::new(
+                0,
+                date,
+                holiday_time,
+                EventType::In,
+                Location::Holiday,
+                Some(0),
+                false,
+            );
+
+            insert_event(&pool.conn, &ev_holiday)?;
+            crate::db::queries::recalc_pairs_for_date(&mut pool.conn, &date)?;
+
+            success(format!("Added HOLIDAY on {}.", date_str));
+            return Ok(());
+        }
+
         // CASE A: only lunch update
         if start.is_none() && end.is_none() && lunch.is_some() {
             if !has_events {

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -216,7 +216,6 @@ pub fn update_event(conn: &Connection, ev: &Event) -> AppResult<()> {
 pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResult<()> {
     let date_str = date.format("%Y-%m-%d").to_string();
 
-    // 1) Load events ordered by time
     let mut stmt = conn.prepare(
         "SELECT * FROM events
          WHERE date = ?1
@@ -230,15 +229,12 @@ pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResu
     }
 
     if events.is_empty() {
-        return Ok(()); // nothing to do
+        return Ok(());
     }
 
-    // ------------------------------------------------
-    // ✅ HOLIDAY handling (pair is NOT NULL, default 0)
-    // ------------------------------------------------
+    // ✅ Holiday marker handling
     let has_holiday = events.iter().any(|e| e.location == Location::Holiday);
     if has_holiday {
-        // Se Holiday coesiste con altri eventi, giornata incoerente
         if events.len() > 1 {
             return Err(AppError::InvalidTime(format!(
                 "Invalid sequence on {}: Holiday cannot coexist with IN/OUT events.",
@@ -246,7 +242,6 @@ pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResu
             )));
         }
 
-        // Solo Holiday marker: forza pair=0 e termina
         conn.execute(
             "UPDATE events SET pair = 0 WHERE date = ?1",
             params![date_str],
@@ -254,30 +249,18 @@ pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResu
         return Ok(());
     }
 
-    // 2) Recalculate pairs with **strict validation**
     let mut current_pair = 1;
-    let mut open_in: Option<i32> = None; // stores ID of last IN without OUT
+    let mut open_in: Option<i32> = None;
 
     for ev in &events {
-        // (Ridondante dopo il guard sopra, ma mantiene robustezza futura)
-        if ev.location == Location::Holiday {
-            conn.execute("UPDATE events SET pair = 0 WHERE id = ?1", params![ev.id])?;
-            continue;
-        }
-
         if ev.kind.is_in() {
-            //
-            // CASE: IN event
-            //
             if open_in.is_some() {
-                // Found IN while previous IN has no OUT → INVALID
                 return Err(AppError::InvalidTime(format!(
                     "Invalid sequence on {}: Found IN at {} but previous pair {} has no OUT.",
                     date_str, ev.time, current_pair
                 )));
             }
 
-            // Assign IN to the current pair
             conn.execute(
                 "UPDATE events SET pair = ?1 WHERE id = ?2",
                 params![current_pair, ev.id],
@@ -285,24 +268,18 @@ pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResu
 
             open_in = Some(ev.id);
         } else if ev.kind.is_out() {
-            //
-            // CASE: OUT event
-            //
             if open_in.is_none() {
-                // Found OUT without IN → INVALID
                 return Err(AppError::InvalidTime(format!(
                     "Invalid sequence on {}: Found OUT at {} without matching IN.",
                     date_str, ev.time
                 )));
             }
 
-            // Assign OUT to the same pair
             conn.execute(
                 "UPDATE events SET pair = ?1 WHERE id = ?2",
                 params![current_pair, ev.id],
             )?;
 
-            // Close the pair and increment
             open_in = None;
             current_pair += 1;
         }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -233,11 +233,38 @@ pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResu
         return Ok(()); // nothing to do
     }
 
+    // ------------------------------------------------
+    // ✅ HOLIDAY handling (pair is NOT NULL, default 0)
+    // ------------------------------------------------
+    let has_holiday = events.iter().any(|e| e.location == Location::Holiday);
+    if has_holiday {
+        // Se Holiday coesiste con altri eventi, giornata incoerente
+        if events.len() > 1 {
+            return Err(AppError::InvalidTime(format!(
+                "Invalid sequence on {}: Holiday cannot coexist with IN/OUT events.",
+                date_str
+            )));
+        }
+
+        // Solo Holiday marker: forza pair=0 e termina
+        conn.execute(
+            "UPDATE events SET pair = 0 WHERE date = ?1",
+            params![date_str],
+        )?;
+        return Ok(());
+    }
+
     // 2) Recalculate pairs with **strict validation**
     let mut current_pair = 1;
     let mut open_in: Option<i32> = None; // stores ID of last IN without OUT
 
     for ev in &events {
+        // (Ridondante dopo il guard sopra, ma mantiene robustezza futura)
+        if ev.location == Location::Holiday {
+            conn.execute("UPDATE events SET pair = 0 WHERE id = ?1", params![ev.id])?;
+            continue;
+        }
+
         if ev.kind.is_in() {
             //
             // CASE: IN event
@@ -280,10 +307,6 @@ pub fn recalc_pairs_for_date(conn: &mut Connection, date: &NaiveDate) -> AppResu
             current_pair += 1;
         }
     }
-
-    // If after processing all events an IN is left open → it's allowed
-    // because user may not have entered OUT yet (ongoing workday)
-    // BUT the next IN will be rejected until OUT is inserted.
 
     Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,6 +43,9 @@ pub enum AppError {
     // ---------------------------
     // Logic errors
     // ---------------------------
+    #[error("Invalid arguments: {0}")]
+    InvalidArgs(String),
+
     #[error("No events found for date {0}")]
     NoEventsForDate(String),
 

--- a/src/utils/colors.rs
+++ b/src/utils/colors.rs
@@ -12,6 +12,8 @@ pub const YELLOW: &str = "\x1b[33m";
 pub const BLUE: &str = "\x1b[34m";
 pub const CYAN: &str = "\x1b[36m";
 pub const MAGENTA: &str = "\x1b[35m";
+pub const SECTION_BAR: &str = "\x1b[1;100;97m"; // bold, bright-black background, white text
+
 
 /// Returns GREY when the field is empty (None or "" or "--:--"),
 /// and RESET otherwise.

--- a/src/utils/colors.rs
+++ b/src/utils/colors.rs
@@ -14,7 +14,6 @@ pub const CYAN: &str = "\x1b[36m";
 pub const MAGENTA: &str = "\x1b[35m";
 pub const SECTION_BAR: &str = "\x1b[1;100;97m"; // bold, bright-black background, white text
 
-
 /// Returns GREY when the field is empty (None or "" or "--:--"),
 /// and RESET otherwise.
 pub fn color_for_optional_field<T: AsRef<str>>(value: Option<T>) -> &'static str {

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -1,5 +1,7 @@
 //! Formatting utilities used for CLI and export outputs.
 
+pub const FOOTER_INDENT: usize = 75;
+
 pub fn bold(s: &str) -> String {
     format!("\x1b[1m{}\x1b[0m", s)
 }
@@ -32,7 +34,7 @@ pub fn mins2readable(mins: i64, want_sign: bool, short: bool) -> String {
 
     if short {
         // es: +02:25 oppure -01:10
-        format!("{}{:02}:{:02}", sign, hours, minutes)
+        format!("{}{:02}h{:02}m", sign, hours, minutes)
     } else {
         // es: +02h 25m oppure -01h 10m
         format!("{}{:02}h {:02}m", sign, hours, minutes)
@@ -50,4 +52,42 @@ pub fn describe_position(code: &str) -> (String, &'static str) {
         "M" => ("Mixed".into(), "\x1b[35m"),
         other => (other.to_string(), "\x1b[0m"),
     }
+}
+
+/// Returns the visible length of a string by ignoring ANSI escape sequences.
+pub fn visible_len(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    let mut count = 0usize;
+
+    while i < bytes.len() {
+        // ANSI escape starts with ESC [
+        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+            i += 2; // skip ESC[
+            // skip until a final byte in the range @..~ (CSI terminator). Most common is 'm'.
+            while i < bytes.len() {
+                let b = bytes[i];
+                i += 1;
+                if (0x40..=0x7E).contains(&b) {
+                    break;
+                }
+            }
+        } else {
+            // Count UTF-8 chars properly
+            let ch = s[i..].chars().next().unwrap();
+            count += 1;
+            i += ch.len_utf8();
+        }
+    }
+
+    count
+}
+
+/// Pads the given visible text to the right edge of a fixed-width box (table).
+/// `box_width` is the target visible width.
+/// Returns a string of spaces to prefix.
+pub fn right_pad_prefix(box_width: usize, visible_text: &str) -> String {
+    let len = visible_len(visible_text);
+    let pad = box_width.saturating_sub(len);
+    " ".repeat(pad)
 }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -10,7 +10,12 @@ pub struct Table {
     pub rows: Vec<Vec<String>>,
 }
 
-pub const DAILY_TABLE_WIDTH: usize = 78;
+pub const DAILY_TABLE_WIDTH: usize = 80;
+pub const DAILY_TABLE_NO_WEEKDAY_WIDTH: usize = 74;
+pub const DAILY_TABLE_WEEKDAYS_SHORT_WIDTH: usize = 79;
+pub const DAILY_TABLE_WEEKDAYS_MEDIUM_WIDTH: usize = 80;
+pub const DAILY_TABLE_WEEKDAYS_LONG_WIDTH: usize = 86;
+pub const DAILY_TABLE_COMPACT_WIDTH: usize = 75;
 pub const EVENTS_TABLE_WIDTH: usize = 88;
 
 impl Table {

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -10,6 +10,9 @@ pub struct Table {
     pub rows: Vec<Vec<String>>,
 }
 
+pub const DAILY_TABLE_WIDTH: usize = 78;
+pub const EVENTS_TABLE_WIDTH: usize = 88;
+
 impl Table {
     pub fn new(columns: Vec<Column>) -> Self {
         Self {


### PR DESCRIPTION
## Summary

This PR introduces a major refinement of the list command output, improving readability, consistency, and flexibility across different display modes.

Key goals were:

- reduce visual clutter,
- make monthly overviews more compact,
- align layout dynamically with configuration,
- clarify time expectations and surplus reporting.

## What’s changed

### 📋 List command

- Unified date + weekday into a single column (YYYY-MM-DD (Weekday)), with automatic fallback to date-only when weekday display is disabled
- Added a new list --compact mode for high-density monthly overviews
- Prevented incompatible flag combinations (--compact + --details)
- Improved month separators and header re-printing when crossing months

### 🗓️ Weekday handling

- Introduced a clear weekday display strategy (None / Short / Medium / Long)
- Table layout dynamically adapts to weekday configuration
- Compact view always uses short weekday notation for stability

### 🧮 Calculations & semantics

- Clarified Target end (planned exit time) semantics
- Improved ΔWORK (worked surplus) calculation and formatting
- Explicit handling of Holiday days with placeholder times and neutral surplus

### 🎨 Output & layout

- Reworked headers, separators, and footers for visual consistency
- Dynamic table width calculation and right-aligned footer
- Reduced column redundancy and improved spacing

### 📚 Documentation

- Updated README (English)
- Updated CHANGELOG for v0.8.1

## Notes

- No database schema changes
- No breaking CLI changes
- Existing configurations continue to work as-is

## Checklist

- Feature implemented and tested
- Output validated for normal and compact modes
- README updated
- CHANGELOG updated
