### PR TITLE
fix(list): include non-work gaps in TGT calculation and align ΔWORK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [0.8.7] - 2026-04-27
+
+### 🐛 Fixed
+
+- Fixed incorrect `TGT` (target end time) calculation in presence of non-work gaps.
+    - Previously, `TGT` was computed as:
+      ```
+      first_in + expected_work_time
+      ```
+      ignoring any non-working gaps (e.g. personal absences).
+    - This caused a mismatch between `TGT` and `ΔWORK`.
+
+- Updated `TGT` calculation to include non-work gaps:
+    ```
+    TGT = first_in + expected_work_time + total_non_work_gaps
+    ```
+
+- Simplified `ΔWORK` computation:
+- Now consistently calculated as:
+  ```
+  ΔWORK = OUT - TGT
+  ```
+- Removed implicit subtraction of non-work gaps to avoid double counting.
+
+### ✅ Improvements
+
+- Ensured full consistency between:
+- displayed `TGT`
+- displayed `OUT`
+- computed `ΔWORK`
+
+- Aligned behavior across:
+- standard `list` output
+- `--compact` view
+
+### 🧠 Notes
+
+- Core working time calculation was already correct; this fix addresses a **display inconsistency only**.
+- No database or schema changes required.
+- No changes to `expected.rs`.
+
+### 📊 Example
+
+Before:
+
+```
+OUT 17:28 | TGT 17:18 | ΔWORK -00h35m ❌ inconsistent
+```
+
+After:
+
+```
+OUT 17:28 | TGT 18:03 | ΔWORK -00h35m ✅ consistent
+```
+
+---
+
 ## [0.8.6] - 2026-02-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,7 +873,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rtimelogger"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "ansi_term",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtimelogger"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"
@@ -25,7 +25,7 @@ winresource = "0.1.28"
 OriginalFilename = "rtimelogger.exe"
 FileDescription = "rTimelogger - Time Tracking Utility"
 ProductName = "rTimelogger"
-ProductVersion = "0.8.5"
+ProductVersion = "0.8.7"
 LegalCopyright = "© 2025 Alessandro Maestri"
 Icon = "res/rtimelogger.ico"
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,40 @@ and computes **expected exit time** and **daily surplus** accurately.
 
 ---
 
-## 🚀 What’s new in **v0.8.2**
+## 🚀 What's new in **v0.8.7**
 
-### 🗄️ Database migration
+### 🐛 Fixed — TGT calculation with non-work gaps (v0.8.7)
 
-Starting from **v0.8.2**, rTimelogger automatically migrates the database schema to support the new `National holiday`
-position.
+The `TGT` (target exit time) calculation was incorrect when non-working gaps were present between pairs.
 
-- The migration extends the `events.position` CHECK constraint
-- The migration is **idempotent** (no changes are applied if the schema is already up to date)
-- No manual action is required
+- **Before**: `TGT = first_in + expected_work_time` (gaps ignored → mismatch with ΔWORK)
+- **After**: `TGT = first_in + expected_work_time + total_non_work_gaps` (consistent)
+- `ΔWORK` is now always computed as `OUT − TGT`, removing implicit double-counting
+- No database or schema changes required
 
-### 🧭 Notes
+### 🤒 Sick Leave marker day (v0.8.6)
 
-- Holiday should be used for personal leave days
-- National holiday should be used for public holidays defined by law or company calendar
-- Future versions may introduce calendar-based automation for national holidays
+A new day position **Sick Leave** (`S`) has been introduced.
+
+- Use `--pos s` to mark a sick leave day
+- Optional `--to <DATE>` to apply sick leave over a date range (the command `DATE` is the start)
+- Weekends, national holidays and dates already containing events are automatically skipped
+- Sick Leave days do not contribute to ΔWORK totals and display `--:--` for all time fields
+
+### ➕ Show target exit on IN event (v0.8.5)
+
+After adding an `IN` event, the calculated **target exit time (TGT)** is now immediately displayed in the output,
+so you always know when you need to leave.
+
+### 📋 National Holiday rendering improvements (v0.8.4)
+
+- The `meta` field (e.g. holiday name) is now shown **instead of** `--:--` placeholders for National Holiday days
+- The holiday row layout adapts dynamically to the current table width and weekday display mode
+- Meta values are Unicode-safe: filtered, concatenated, and truncated with a trailing `…` when needed
+
+### 📥 JSON / CSV holiday import (v0.8.3)
+
+See the **Import data** section below for full documentation.
 
 ---
 
@@ -43,6 +61,7 @@ position.
     * `C` Client / On-site
     * `N` National holiday
     * `H` Holiday
+    * `S` Sick Leave
     * `M` Mixed
 * Automatic calculation of:
 
@@ -200,6 +219,9 @@ rtimelogger add 2025-12-15 --in 09:00 --lunch 30 --out 17:30
 rtimelogger add 2025-12-15 --edit --pair 1 --out 18:00
 rtimelogger add 2025-12-15 --out 10:30 --work-gap
 rtimelogger add 2025-12-15 --edit --pair 2 --no-work-gap
+rtimelogger add 2025-12-25 --pos n
+rtimelogger add 2025-03-10 --pos s
+rtimelogger add 2025-03-10 --pos s --to 2025-03-14
 ```
 
 ### 📌 Day positions
@@ -216,6 +238,7 @@ rTimelogger supports multiple day positions to describe how a working day (or no
 | `M`  | Mixed            | Mixed working locations                                       |
 | `H`  | Holiday          | Personal holiday (counts against personal leave allowance)    |
 | `N`  | National holiday | Public holiday (does **not** affect personal leave allowance) |
+| `S`  | Sick Leave       | Sick day (non-working marker, does not reduce holiday budget) |
 
 ### ➕ Adding a national holiday
 
@@ -264,6 +287,35 @@ Example:
 | Expected time            | ❌             | ❌                      |
 | ΔWORK contribution       | ❌             | ❌                      |
 | Requires time entries    | ❌             | ❌                      |
+
+---
+
+### 🤒 Adding a sick leave day
+
+To mark a **sick leave day**, use the `add` command with the sick leave position.
+
+```bash
+rtimelogger add 2025-03-10 --pos s
+```
+
+To mark a **sick leave range** (e.g. a week), add the `--to` option:
+
+```bash
+rtimelogger add 2025-03-10 --pos s --to 2025-03-14
+```
+
+**Behavior**
+
+- No `--in`, `--out`, `--lunch`, or `--work-gap` parameters are allowed
+- The day (or range) is recorded as a non-working sick leave marker
+- Weekends, national holidays, and dates that already contain events are automatically skipped
+- Sick leave days do not contribute to worked time and are not deducted from personal holiday allowance
+
+**Output example**
+
+```text
+2025-03-10 (Mon) | Sick Leave | --:-- | --:-- | --:-- | --:-- | -
+```
 
 ---
 

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -142,6 +142,17 @@ fn remaining_width(total_width: usize, plain_prefix: &str) -> usize {
     total_width.saturating_sub(plain_prefix.len())
 }
 
+/// Returns the total duration, in minutes, of gaps that are not marked as work gaps.
+fn total_non_work_gap_minutes(summary: &DaySummary) -> i64 {
+    summary
+        .timeline
+        .gaps
+        .iter()
+        .filter(|g| !g.is_work_gap)
+        .map(|g| g.duration_minutes)
+        .sum()
+}
+
 //
 // ───────────────────────────────────────────────────────────────────────────────
 // Public entry
@@ -518,7 +529,10 @@ fn print_daily_row(
         }
 
         // Target end
-        let expected_exit = first_in + chrono::Duration::minutes(summary.expected);
+        let non_work_gap_minutes = total_non_work_gap_minutes(summary);
+        let expected_exit = first_in
+            + chrono::Duration::minutes(summary.expected)
+            + chrono::Duration::minutes(non_work_gap_minutes);
         expected_exit_str = expected_exit.format("%H:%M").to_string();
 
         // Lunch
@@ -536,15 +550,7 @@ fn print_daily_row(
         end_c = colors::colorize_optional(&end_str);
 
         // Surplus (worked)
-        let non_work_gap_minutes: i64 = timeline
-            .gaps
-            .iter()
-            .filter(|g| !g.is_work_gap)
-            .map(|g| g.duration_minutes)
-            .sum();
-
-        surplus_opt =
-            last_out_opt.map(|out| (out - expected_exit).num_minutes() - non_work_gap_minutes);
+        surplus_opt = last_out_opt.map(|out| (out - expected_exit).num_minutes());
 
         match surplus_opt {
             None => {
@@ -771,18 +777,13 @@ fn print_daily_row_compact(
         "--:--".to_string()
     };
 
-    let expected_exit = first_in + chrono::Duration::minutes(summary.expected);
+    let non_work_gap_minutes = total_non_work_gap_minutes(summary);
+    let expected_exit = first_in
+        + chrono::Duration::minutes(summary.expected)
+        + chrono::Duration::minutes(non_work_gap_minutes);
     let target_end_str = expected_exit.format("%H:%M").to_string();
 
-    let non_work_gap_minutes: i64 = timeline
-        .gaps
-        .iter()
-        .filter(|g| !g.is_work_gap)
-        .map(|g| g.duration_minutes)
-        .sum();
-
-    let surplus_opt =
-        last_out_opt.map(|out| (out - expected_exit).num_minutes() - non_work_gap_minutes);
+    let surplus_opt = last_out_opt.map(|out| (out - expected_exit).num_minutes());
 
     let (delta_str, delta_color) = match surplus_opt {
         None => ("-".to_string(), colors::GREY),


### PR DESCRIPTION
Fix incorrect TGT (target end time) calculation in presence of non-work gaps. Previously, TGT was computed as `first_in + expected_work_time`, ignoring personal absences (non-work gaps), causing inconsistencies with ΔWORK.

Updated logic:
- TGT now includes non-work gaps: TGT = first_in + expected_work_time + non_work_gaps
- ΔWORK is now consistently calculated as: ΔWORK = OUT - TGT
- Removed implicit subtraction of non-work gaps to avoid double counting

Applied changes to:
- standard list output
- compact list output

Also updated documentation:
- CHANGELOG.md with fix details and example
- README.md to clarify TGT behavior

No changes to core work time calculation or database schema.

Closes #43